### PR TITLE
Adds a way to automatically add a Spark.function tied to an instance of one of our Equipment classes at construction time.

### DIFF
--- a/firmware/rhizome.ino
+++ b/firmware/rhizome.ino
@@ -73,7 +73,7 @@ void setup() {
     ((Ohmbrewer::RIMS*)sprouts.front())->setState(true); // Turn everything on.
     ((Ohmbrewer::RIMS*)sprouts.front())->getTube()->setTargetTemp(559);
 
-    sprouts.push_back(new Ohmbrewer::Pump( 1, new std::list<int>(1,5) ));
+    sprouts.push_back(new Ohmbrewer::Pump( 2, new std::list<int>(1,5) ));
 
     screen.initScreen();
 }

--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -160,7 +160,7 @@ const int Ohmbrewer::Equipment::display(Ohmbrewer::Screen *screen) {
  * @returns The time taken to run the method
  */
 int Ohmbrewer::Equipment::update(String args) {
-    return doUpdate(args);
+    return doUpdate(&args);
 }
 
 /**

--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -126,6 +126,18 @@ void Ohmbrewer::Equipment::getUpdateFunctionName(String* buffer) const {
 }
 
 /**
+ * Registers the given function name for use with the Particle Cloud as the way to run update().
+ * @param name The name that should appear on the Particle Cloud that will be used to kick off update()
+ * @returns Any error code thrown during registration
+ */
+//int Ohmbrewer::Equipment::registerUpdateFunction(const char* name) {
+int Ohmbrewer::Equipment::registerUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    return Spark.function(updateFunction.c_str(), [this](const String& args) -> int { return this->update(args); } );
+}
+
+/**
  * Performs the Equipment's current task. Expect to use this during loop().
  * @returns The time taken to run the method
  */

--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -112,12 +112,25 @@ const int Ohmbrewer::Equipment::setCurrentTask(String currentTask) {
  * The Particle event stream to publish Equipment status updates to.
  * @returns The Particle event stream the Equipment expects to publish to.
  */
-String Ohmbrewer::Equipment::getStream() {
+String Ohmbrewer::Equipment::getStream() const {
     String stream = String("/");
     stream.concat(this->getType());
     stream.concat("/");
     stream.concat(this->getID());
     return stream;
+}
+
+/**
+ * The name of the Spark.function for updating this Sprout.
+ * Currently, looks like "type_#" where # is the Sprout's ID number.
+ * Assumes that the buffer is empty!
+ * @param buffer Buffer to fill with the name
+ * @returns The name of the Spark.function for updating this Sprout
+ */
+void Ohmbrewer::Equipment::getUpdateFunctionName(String* buffer) const {
+    buffer->concat(getType());
+    buffer->concat("_");
+    buffer->concat(getID());
 }
 
 /**
@@ -139,10 +152,11 @@ const int Ohmbrewer::Equipment::display(Ohmbrewer::Screen *screen) {
 
 /**
  * Publishes updates to Ohmbrewer, etc.
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-const int Ohmbrewer::Equipment::update() {
-    return doUpdate();
+int Ohmbrewer::Equipment::update(String args) {
+    return doUpdate(args);
 }
 
 /**

--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -59,14 +59,6 @@ int Ohmbrewer::Equipment::getID() const {
 }
 
 /**
- * The Equipment Type
- * @returns The Equipment type name
- */
-const char* Ohmbrewer::Equipment::getType() const {
-    return _type;
-}
-
-/**
  * The time at which the Equipment will stop operating.
  * @returns The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
  */

--- a/lib/Ohmbrewer_Equipment.h
+++ b/lib/Ohmbrewer_Equipment.h
@@ -23,11 +23,15 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "equipment";
+
+            /**
              * A map of arguments provided via a Particle cloud function call,
              * mapped to the appropriate Equipment members.
              */
             typedef std::map <String, String> args_map_t;
-
 
             /**
              * The Equipment ID
@@ -39,7 +43,7 @@ namespace Ohmbrewer {
              * The Equipment Type
              * @returns The Equipment type name
              */
-            const char* getType() const;
+            virtual const char* getType() const { return Equipment::TYPE_NAME; };
 
             /**
              * The time at which the Equipment will stop operating.
@@ -79,7 +83,7 @@ namespace Ohmbrewer {
              * @param buffer Buffer to fill with the name
              * @returns The name of the Spark.function for updating this Sprout
              */
-            void getUpdateFunctionName(String* buffer) const;
+            virtual void getUpdateFunctionName(String* buffer) const;
 
             /**
              * Performs the Equipment's current task. Expect to use this during loop().
@@ -211,11 +215,6 @@ namespace Ohmbrewer {
              * Equipment ID
              */
             int            _id;
-
-            /**
-             * Equipment Type
-             */
-            const char*    _type;
 
             /**
              * Designated Stop Time

--- a/lib/Ohmbrewer_Equipment.h
+++ b/lib/Ohmbrewer_Equipment.h
@@ -208,7 +208,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            virtual int doUpdate(String args) = 0;
+            virtual int doUpdate(String* args) = 0;
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_Equipment.h
+++ b/lib/Ohmbrewer_Equipment.h
@@ -86,6 +86,12 @@ namespace Ohmbrewer {
             virtual void getUpdateFunctionName(String* buffer) const;
 
             /**
+             * Registers the function name for use with the Particle Cloud as the way to run update().
+             * @returns Any error code thrown during registration
+             */
+            int registerUpdateFunction();
+
+            /**
              * Performs the Equipment's current task. Expect to use this during loop().
              * @returns The time taken to run the method
              */

--- a/lib/Ohmbrewer_Equipment.h
+++ b/lib/Ohmbrewer_Equipment.h
@@ -71,7 +71,15 @@ namespace Ohmbrewer {
              * The Particle event stream to publish Equipment status updates to.
              * @returns The Particle event stream the Equipment expects to publish to.
              */
-            String getStream();
+            String getStream() const;
+
+            /**
+             * The name of the Spark.function for updating this Sprout.
+             * Currently, looks like "type_#" where # is the Sprout's ID number.
+             * @param buffer Buffer to fill with the name
+             * @returns The name of the Spark.function for updating this Sprout
+             */
+            void getUpdateFunctionName(String* buffer) const;
 
             /**
              * Performs the Equipment's current task. Expect to use this during loop().
@@ -88,9 +96,10 @@ namespace Ohmbrewer {
 
             /**
              * Publishes updates to Ohmbrewer, etc.
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            const int update();
+            int update(String args);
             
             /**
              * Constructors
@@ -186,9 +195,10 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            virtual int doUpdate() = 0;
+            virtual int doUpdate(String args) = 0;
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_Heating_Element.cpp
+++ b/lib/Ohmbrewer_Heating_Element.cpp
@@ -1,21 +1,12 @@
 #include "Ohmbrewer_Heating_Element.h"
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::HeatingElement::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::HeatingElement>(updateFunction.c_str(), &Ohmbrewer::HeatingElement::update, this);
-}
-
-/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -28,7 +19,7 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbre
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stopTime,
                                           bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -37,7 +28,7 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stop
  */
 Ohmbrewer::HeatingElement::HeatingElement(const HeatingElement& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_Heating_Element.cpp
+++ b/lib/Ohmbrewer_Heating_Element.cpp
@@ -1,12 +1,22 @@
 #include "Ohmbrewer_Heating_Element.h"
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::HeatingElement::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::HeatingElement>(updateFunction.c_str(), &Ohmbrewer::HeatingElement::update, this);
+}
+
+/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
     _type = "heat";
+    addUpdateFunction();
 }
 
 /**
@@ -20,6 +30,7 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbre
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stopTime,
                                           bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
     _type = "heat";
+    addUpdateFunction();
 }
 
 /**
@@ -29,6 +40,7 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stop
 Ohmbrewer::HeatingElement::HeatingElement(const HeatingElement& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
     _type = "heat";
+    addUpdateFunction();
 }
 
 /**
@@ -65,9 +77,10 @@ int Ohmbrewer::HeatingElement::doDisplay(Ohmbrewer::Screen *screen) {
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::HeatingElement::doUpdate() {
+int Ohmbrewer::HeatingElement::doUpdate(String args) {
     // TODO: Implement HeatingElement::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Heating_Element.cpp
+++ b/lib/Ohmbrewer_Heating_Element.cpp
@@ -15,7 +15,6 @@ void Ohmbrewer::HeatingElement::addUpdateFunction() {
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
-    _type = "heat";
     addUpdateFunction();
 }
 
@@ -29,7 +28,6 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbre
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stopTime,
                                           bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
-    _type = "heat";
     addUpdateFunction();
 }
 
@@ -39,7 +37,6 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stop
  */
 Ohmbrewer::HeatingElement::HeatingElement(const HeatingElement& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
-    _type = "heat";
     addUpdateFunction();
 }
 

--- a/lib/Ohmbrewer_Heating_Element.cpp
+++ b/lib/Ohmbrewer_Heating_Element.cpp
@@ -68,7 +68,7 @@ int Ohmbrewer::HeatingElement::doDisplay(Ohmbrewer::Screen *screen) {
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::HeatingElement::doUpdate(String args) {
+int Ohmbrewer::HeatingElement::doUpdate(String* args) {
     // TODO: Implement HeatingElement::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Heating_Element.h
+++ b/lib/Ohmbrewer_Heating_Element.h
@@ -87,12 +87,6 @@ namespace Ohmbrewer {
              */
             int doUpdate(String args);
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
-
     };
 };
 

--- a/lib/Ohmbrewer_Heating_Element.h
+++ b/lib/Ohmbrewer_Heating_Element.h
@@ -85,7 +85,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
     };
 };

--- a/lib/Ohmbrewer_Heating_Element.h
+++ b/lib/Ohmbrewer_Heating_Element.h
@@ -71,9 +71,16 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
+
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
 
     };
 };

--- a/lib/Ohmbrewer_Heating_Element.h
+++ b/lib/Ohmbrewer_Heating_Element.h
@@ -21,6 +21,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "heat";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return HeatingElement::TYPE_NAME; };
+
+            /**
              * Constructor
              * @param id The Sprout ID to use for this piece of Equipment
              * @param pins The list of physical pins this Equipment is attached to

--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -1,21 +1,12 @@
 #include "Ohmbrewer_Pump.h"
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::Pump::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::Pump>(updateFunction.c_str(), &Ohmbrewer::Pump::update, this);
-}
-
-/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -28,7 +19,7 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins)
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -37,7 +28,7 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
  */
 Ohmbrewer::Pump::Pump(const Pump& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -1,12 +1,22 @@
 #include "Ohmbrewer_Pump.h"
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::Pump::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::Pump>(updateFunction.c_str(), &Ohmbrewer::Pump::update, this);
+}
+
+/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
     _type = "pump";
+    addUpdateFunction();
 }
 
 /**
@@ -20,6 +30,7 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins)
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
     _type = "pump";
+    addUpdateFunction();
 }
 
 /**
@@ -29,6 +40,7 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
 Ohmbrewer::Pump::Pump(const Pump& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
     _type = "pump";
+    addUpdateFunction();
 }
 
 /**
@@ -65,9 +77,10 @@ int Ohmbrewer::Pump::doDisplay(Ohmbrewer::Screen *screen) {
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Pump::doUpdate() {
+int Ohmbrewer::Pump::doUpdate(String args) {
     // TODO: Implement Pump::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -68,7 +68,7 @@ int Ohmbrewer::Pump::doDisplay(Ohmbrewer::Screen *screen) {
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Pump::doUpdate(String args) {
+int Ohmbrewer::Pump::doUpdate(String* args) {
     // TODO: Implement Pump::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -15,7 +15,6 @@ void Ohmbrewer::Pump::addUpdateFunction() {
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins) {
-    _type = "pump";
     addUpdateFunction();
 }
 
@@ -29,7 +28,6 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Relay(id, pins)
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Relay(id, pins, stopTime, state, currentTask) {
-    _type = "pump";
     addUpdateFunction();
 }
 
@@ -39,7 +37,6 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
  */
 Ohmbrewer::Pump::Pump(const Pump& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
-    _type = "pump";
     addUpdateFunction();
 }
 

--- a/lib/Ohmbrewer_Pump.h
+++ b/lib/Ohmbrewer_Pump.h
@@ -71,9 +71,16 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
+
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
 
     };
 };

--- a/lib/Ohmbrewer_Pump.h
+++ b/lib/Ohmbrewer_Pump.h
@@ -21,6 +21,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "pump";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return Pump::TYPE_NAME; };
+
+            /**
              * Constructor
              * @param id The Sprout ID to use for this piece of Equipment
              * @param pins The list of physical pins this Equipment is attached to

--- a/lib/Ohmbrewer_Pump.h
+++ b/lib/Ohmbrewer_Pump.h
@@ -87,11 +87,6 @@ namespace Ohmbrewer {
              */
             int doUpdate(String args);
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
 
     };
 };

--- a/lib/Ohmbrewer_Pump.h
+++ b/lib/Ohmbrewer_Pump.h
@@ -85,7 +85,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
 
     };

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -26,15 +26,6 @@ Ohmbrewer::Pump* Ohmbrewer::RIMS::getRecirculator() const {
 }
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::RIMS::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::RIMS>(updateFunction.c_str(), &Ohmbrewer::RIMS::update, this);
-}
-
-/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
@@ -45,7 +36,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, p
     _tube = new Thermostat(1, fakePins);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -63,7 +54,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tube = new Thermostat(1, fakePins);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -82,7 +73,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tube = new Thermostat(1, fakePins, targetTemp);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -95,7 +86,7 @@ Ohmbrewer::RIMS::RIMS(const Ohmbrewer::RIMS& clonee) : Ohmbrewer::Equipment(clon
     _tunSensor = clonee.getTunSensor();
     _recirc = clonee.getRecirculator();
 
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -275,7 +275,7 @@ unsigned long Ohmbrewer::RIMS::displayRecircStatus(Ohmbrewer::Screen *screen) {
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::RIMS::doUpdate(String args) {
+int Ohmbrewer::RIMS::doUpdate(String* args) {
     // TODO: Implement RIMS::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -45,7 +45,6 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, p
     _tube = new Thermostat(1, fakePins);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    _type = "rims";
     addUpdateFunction();
 }
 
@@ -64,7 +63,6 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tube = new Thermostat(1, fakePins);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    _type = "rims";
     addUpdateFunction();
 }
 
@@ -84,7 +82,6 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tube = new Thermostat(1, fakePins, targetTemp);
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
-    _type = "rims";
     addUpdateFunction();
 }
 
@@ -97,7 +94,6 @@ Ohmbrewer::RIMS::RIMS(const Ohmbrewer::RIMS& clonee) : Ohmbrewer::Equipment(clon
     _tube = clonee.getTube();
     _tunSensor = clonee.getTunSensor();
     _recirc = clonee.getRecirculator();
-    _type = "rims";
 
     addUpdateFunction();
 }

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -26,6 +26,15 @@ Ohmbrewer::Pump* Ohmbrewer::RIMS::getRecirculator() const {
 }
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::RIMS::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::RIMS>(updateFunction.c_str(), &Ohmbrewer::RIMS::update, this);
+}
+
+/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
@@ -37,6 +46,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, p
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
     _type = "rims";
+    addUpdateFunction();
 }
 
 /**
@@ -55,6 +65,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
     _type = "rims";
+    addUpdateFunction();
 }
 
 /**
@@ -74,10 +85,12 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* pins, int stopTime,
     _tunSensor = new TemperatureSensor(1, fakePins);
     _recirc = new Pump(1,fakePins);
     _type = "rims";
+    addUpdateFunction();
 }
 
 /**
  * Copy constructor
+ * FIXME: Copy constructors should probably reset the pins and ID's, no?
  * @param clonee The Equipment object to copy
  */
 Ohmbrewer::RIMS::RIMS(const Ohmbrewer::RIMS& clonee) : Ohmbrewer::Equipment(clonee) {
@@ -85,6 +98,8 @@ Ohmbrewer::RIMS::RIMS(const Ohmbrewer::RIMS& clonee) : Ohmbrewer::Equipment(clon
     _tunSensor = clonee.getTunSensor();
     _recirc = clonee.getRecirculator();
     _type = "rims";
+
+    addUpdateFunction();
 }
 
 /**
@@ -270,9 +285,10 @@ unsigned long Ohmbrewer::RIMS::displayRecircStatus(Ohmbrewer::Screen *screen) {
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::RIMS::doUpdate() {
+int Ohmbrewer::RIMS::doUpdate(String args) {
     // TODO: Implement RIMS::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_RIMS.h
+++ b/lib/Ohmbrewer_RIMS.h
@@ -189,11 +189,6 @@ namespace Ohmbrewer {
              */
             Pump* _recirc;
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
     };
 };
 

--- a/lib/Ohmbrewer_RIMS.h
+++ b/lib/Ohmbrewer_RIMS.h
@@ -166,7 +166,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_RIMS.h
+++ b/lib/Ohmbrewer_RIMS.h
@@ -24,6 +24,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "rims";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return RIMS::TYPE_NAME; };
+
+            /**
              * The Tube thermostat
              * @returns The Thermostat object representing the RIMS tube elements
              */

--- a/lib/Ohmbrewer_RIMS.h
+++ b/lib/Ohmbrewer_RIMS.h
@@ -152,9 +152,10 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the
@@ -177,6 +178,11 @@ namespace Ohmbrewer {
              */
             Pump* _recirc;
 
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
     };
 };
 

--- a/lib/Ohmbrewer_Relay.cpp
+++ b/lib/Ohmbrewer_Relay.cpp
@@ -2,12 +2,24 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::Relay::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::Relay>(updateFunction.c_str(), &Ohmbrewer::Relay::update, this);
+}
+
+/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::Relay::Relay(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
     _type = "relay";
+    // For now, we will not automatically add a Spark.function to Relays as
+    // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
+    // determine if a function for actual Relay types should be added, then we'll change that.
 }
 
 /**
@@ -21,6 +33,9 @@ Ohmbrewer::Relay::Relay(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id,
 Ohmbrewer::Relay::Relay(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
     _type = "relay";
+    // For now, we will not automatically add a Spark.function to Relays as
+    // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
+    // determine if a function for actual Relay types should be added, then we'll change that.
 }
 
 /**
@@ -30,6 +45,9 @@ Ohmbrewer::Relay::Relay(int id, std::list<int>* pins, int stopTime,
 Ohmbrewer::Relay::Relay(const Relay& clonee) : Ohmbrewer::Equipment(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
     _type = "relay";
+    // For now, we will not automatically add a Spark.function to Relays as
+    // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
+    // determine if a function for actual Relay types should be added, then we'll change that.
 }
 
 /**
@@ -157,9 +175,10 @@ int Ohmbrewer::Relay::doDisplay(Ohmbrewer::Screen *screen) {
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Relay::doUpdate() {
+int Ohmbrewer::Relay::doUpdate(String args) {
     // TODO: Implement Relay::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Relay.cpp
+++ b/lib/Ohmbrewer_Relay.cpp
@@ -2,15 +2,6 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::Relay::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::Relay>(updateFunction.c_str(), &Ohmbrewer::Relay::update, this);
-}
-
-/**
  * Constructor
  * @param id The Sprout ID to use for this piece of Equipment
  * @param pins The list of physical pins this Equipment is attached to

--- a/lib/Ohmbrewer_Relay.cpp
+++ b/lib/Ohmbrewer_Relay.cpp
@@ -16,7 +16,6 @@ void Ohmbrewer::Relay::addUpdateFunction() {
  * @param pins The list of physical pins this Equipment is attached to
  */
 Ohmbrewer::Relay::Relay(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
-    _type = "relay";
     // For now, we will not automatically add a Spark.function to Relays as
     // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
     // determine if a function for actual Relay types should be added, then we'll change that.
@@ -32,7 +31,6 @@ Ohmbrewer::Relay::Relay(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id,
  */
 Ohmbrewer::Relay::Relay(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
-    _type = "relay";
     // For now, we will not automatically add a Spark.function to Relays as
     // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
     // determine if a function for actual Relay types should be added, then we'll change that.
@@ -43,8 +41,6 @@ Ohmbrewer::Relay::Relay(int id, std::list<int>* pins, int stopTime,
  * @param clonee The Equipment object to copy
  */
 Ohmbrewer::Relay::Relay(const Relay& clonee) : Ohmbrewer::Equipment(clonee) {
-    // This has probably already been set, but maybe clonee is a more complicated child class...
-    _type = "relay";
     // For now, we will not automatically add a Spark.function to Relays as
     // it's used mostly as a base class and our subclasses call the Relay constructor. If we can find a safe way to
     // determine if a function for actual Relay types should be added, then we'll change that.

--- a/lib/Ohmbrewer_Relay.cpp
+++ b/lib/Ohmbrewer_Relay.cpp
@@ -165,7 +165,7 @@ int Ohmbrewer::Relay::doDisplay(Ohmbrewer::Screen *screen) {
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Relay::doUpdate(String args) {
+int Ohmbrewer::Relay::doUpdate(String* args) {
     // TODO: Implement Relay::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Relay.h
+++ b/lib/Ohmbrewer_Relay.h
@@ -108,9 +108,10 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the
@@ -118,6 +119,12 @@ namespace Ohmbrewer {
              * @returns The list of physical pins that the Equipment is connected to.
              */
             std::list<int>* whichPins() const;
+
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
     };
 };
 

--- a/lib/Ohmbrewer_Relay.h
+++ b/lib/Ohmbrewer_Relay.h
@@ -122,7 +122,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_Relay.h
+++ b/lib/Ohmbrewer_Relay.h
@@ -24,6 +24,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "relay";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return Relay::TYPE_NAME; };
+
+            /**
              * Constructor
              * @param id The Sprout ID to use for this piece of Equipment
              * @param pins The list of physical pins this Equipment is attached to

--- a/lib/Ohmbrewer_Relay.h
+++ b/lib/Ohmbrewer_Relay.h
@@ -131,11 +131,6 @@ namespace Ohmbrewer {
              */
             std::list<int>* whichPins() const;
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
     };
 };
 

--- a/lib/Ohmbrewer_Screen.cpp
+++ b/lib/Ohmbrewer_Screen.cpp
@@ -104,9 +104,9 @@ unsigned long Ohmbrewer::Screen::refreshDisplay() {
 
     // Show the various data readouts
     // FIXME: This ain't quite right... These assume that Thermostats and RIMS would always be the first Sprouts entry.
-    if(strcmp(_sprouts->front()->getType(), "therm") == 0) {
+    if(strcmp(_sprouts->front()->getType(), Thermostat::TYPE_NAME) == 0) {
         displayThermostats();
-    } else if(strcmp(_sprouts->front()->getType(), "rims") == 0) {
+    } else if(strcmp(_sprouts->front()->getType(), RIMS::TYPE_NAME) == 0) {
         displayRIMS();
     } else {
         displayTemps();
@@ -133,9 +133,9 @@ unsigned long Ohmbrewer::Screen::displayRelays() {
     resetTextSizeAndColor();
 
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "temp") != 0 &&
-            strcmp((*itr)->getType(), "rims") != 0 &&
-            strcmp((*itr)->getType(), "therm") != 0) {
+        if (strcmp((*itr)->getType(), TemperatureSensor::TYPE_NAME) != 0 &&
+            strcmp((*itr)->getType(), RIMS::TYPE_NAME) != 0 &&
+            strcmp((*itr)->getType(), Thermostat::TYPE_NAME) != 0) {
             if(!foundFirst) {
                 // Print the header
                 print("====== Relays ======");
@@ -161,7 +161,7 @@ unsigned long Ohmbrewer::Screen::displayHeatingElements() {
     resetTextSizeAndColor();
 
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "heat") == 0) {
+        if (strcmp((*itr)->getType(), HeatingElement::TYPE_NAME) == 0) {
             if(!foundFirst) {
                 // Print the header
                 print("======= Heat =======");
@@ -187,7 +187,7 @@ unsigned long Ohmbrewer::Screen::displayPumps() {
     resetTextSizeAndColor();
 
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "pump") == 0) {
+        if (strcmp((*itr)->getType(), Pump::TYPE_NAME) == 0) {
             if(!foundFirst) {
                 // Print the header
                 print("======= Pumps ======");
@@ -213,7 +213,7 @@ unsigned long Ohmbrewer::Screen::displayTemps() {
     resetTextSizeAndColor();
 
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "temp") == 0) {
+        if (strcmp((*itr)->getType(), TemperatureSensor::TYPE_NAME) == 0) {
             if(!foundFirst) {
                 // Print the header
                 print("= Temperature (");
@@ -241,7 +241,7 @@ unsigned long Ohmbrewer::Screen::displayThermostats() {
 
     printMargin(2);
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "therm") == 0) {
+        if (strcmp((*itr)->getType(), Thermostat::TYPE_NAME) == 0) {
             ((Ohmbrewer::Thermostat*)(*itr))->display(this);
         }
     }
@@ -261,7 +261,7 @@ unsigned long Ohmbrewer::Screen::displayRIMS() {
 
     printMargin(2);
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), "rims") == 0) {
+        if (strcmp((*itr)->getType(), RIMS::TYPE_NAME) == 0) {
             ((Ohmbrewer::RIMS*)(*itr))->display(this);
         }
     }

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -43,7 +43,6 @@ const int Ohmbrewer::TemperatureSensor::setLastReadTime(const int lastReadTime) 
 Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
-    _type = "temp";
     addUpdateFunction();
 }
 
@@ -58,7 +57,6 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins) : 
 Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins, int stopTime, bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
-    _type = "temp";
     addUpdateFunction();
 }
 
@@ -69,7 +67,6 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins, in
 Ohmbrewer::TemperatureSensor::TemperatureSensor(const TemperatureSensor& clonee) : Ohmbrewer::Equipment(clonee) {
     _lastReading = clonee.getTemp();
     _lastReadTime = Time.now();
-    _type = "temp";
     addUpdateFunction();
 }
 

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -168,7 +168,7 @@ int Ohmbrewer::TemperatureSensor::doDisplay(Ohmbrewer::Screen *screen) {
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::TemperatureSensor::doUpdate(String args) {
+int Ohmbrewer::TemperatureSensor::doUpdate(String* args) {
     // TODO: Implement TemperatureSensor::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -2,6 +2,15 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::TemperatureSensor::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::TemperatureSensor>(updateFunction.c_str(), &Ohmbrewer::TemperatureSensor::update, this);
+}
+
+/**
  * The last temperature read by the sensor. Currently returns in Celsius.
  * @returns The last temperature reading
  */
@@ -35,6 +44,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins) : 
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
     _type = "temp";
+    addUpdateFunction();
 }
 
 /**
@@ -49,6 +59,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins, in
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
     _type = "temp";
+    addUpdateFunction();
 }
 
 /**
@@ -59,6 +70,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(const TemperatureSensor& clonee)
     _lastReading = clonee.getTemp();
     _lastReadTime = Time.now();
     _type = "temp";
+    addUpdateFunction();
 }
 
 /**
@@ -165,9 +177,10 @@ int Ohmbrewer::TemperatureSensor::doDisplay(Ohmbrewer::Screen *screen) {
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::TemperatureSensor::doUpdate() {
+int Ohmbrewer::TemperatureSensor::doUpdate(String args) {
     // TODO: Implement TemperatureSensor::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -2,15 +2,6 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::TemperatureSensor::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::TemperatureSensor>(updateFunction.c_str(), &Ohmbrewer::TemperatureSensor::update, this);
-}
-
-/**
  * The last temperature read by the sensor. Currently returns in Celsius.
  * @returns The last temperature reading
  */
@@ -43,7 +34,7 @@ const int Ohmbrewer::TemperatureSensor::setLastReadTime(const int lastReadTime) 
 Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -57,7 +48,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins) : 
 Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins, int stopTime, bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
     _lastReading = new Temperature(0);
     _lastReadTime = Time.now();
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -67,7 +58,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, std::list<int>* pins, in
 Ohmbrewer::TemperatureSensor::TemperatureSensor(const TemperatureSensor& clonee) : Ohmbrewer::Equipment(clonee) {
     _lastReading = clonee.getTemp();
     _lastReadTime = Time.now();
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -139,7 +139,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -125,9 +125,10 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the
@@ -145,6 +146,12 @@ namespace Ohmbrewer {
              * Last time the temperature was read by the sensor
              */
             int _lastReadTime;
+
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
 
     };
 };

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -22,6 +22,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "temp";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return TemperatureSensor::TYPE_NAME; };
+
+            /**
              * The last temperature read by the sensor. Currently returns in Celsius.
              * @returns The last temperature reading
              */

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -158,12 +158,6 @@ namespace Ohmbrewer {
              */
             int _lastReadTime;
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
-
     };
 };
 

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -2,6 +2,15 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
+ * Adds the update function for the instance.
+ */
+void Ohmbrewer::Thermostat::addUpdateFunction() {
+    String updateFunction;
+    getUpdateFunctionName(&updateFunction);
+    Spark.function<Ohmbrewer::Thermostat>(updateFunction.c_str(), &Ohmbrewer::Thermostat::update, this);
+}
+
+/**
  * The desired target temperature. Defaults to Celsius
  * @returns The target temperature in Celsius
  */
@@ -50,6 +59,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins) : Ohmbrewer::Equ
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
     _type = "therm";
+    addUpdateFunction();
 }
 
 /**
@@ -65,6 +75,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, const double tar
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
     _type = "therm";
+    addUpdateFunction();
 }
 
 /**
@@ -83,6 +94,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
     _type = "therm";
+    addUpdateFunction();
 }
 
 /**
@@ -103,6 +115,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
     _type = "therm";
+    addUpdateFunction();
 }
 
 /**
@@ -114,6 +127,7 @@ Ohmbrewer::Thermostat::Thermostat(const Ohmbrewer::Thermostat& clonee) : Ohmbrew
     _tempSensor = clonee.getSensor();
     _targetTemp = clonee.getTargetTemp();
     _type = "therm";
+    addUpdateFunction();
 }
 
 /**
@@ -304,9 +318,10 @@ unsigned long Ohmbrewer::Thermostat::displayTemp(double temp, char* label, uint1
 /**
  * Publishes updates to Ohmbrewer, etc.
  * This function is called by update().
+ * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Thermostat::doUpdate() {
+int Ohmbrewer::Thermostat::doUpdate(String args) {
     // TODO: Implement Thermostat::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -58,7 +58,6 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins) : Ohmbrewer::Equ
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
-    _type = "therm";
     addUpdateFunction();
 }
 
@@ -74,7 +73,6 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, const double tar
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
-    _type = "therm";
     addUpdateFunction();
 }
 
@@ -93,7 +91,6 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
-    _type = "therm";
     addUpdateFunction();
 }
 
@@ -114,7 +111,6 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
-    _type = "therm";
     addUpdateFunction();
 }
 
@@ -126,7 +122,6 @@ Ohmbrewer::Thermostat::Thermostat(const Ohmbrewer::Thermostat& clonee) : Ohmbrew
     _heatingElm = clonee.getElement();
     _tempSensor = clonee.getSensor();
     _targetTemp = clonee.getTargetTemp();
-    _type = "therm";
     addUpdateFunction();
 }
 

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -307,7 +307,7 @@ unsigned long Ohmbrewer::Thermostat::displayTemp(double temp, char* label, uint1
  * @param args The argument string passed into the Particle Cloud
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Thermostat::doUpdate(String args) {
+int Ohmbrewer::Thermostat::doUpdate(String* args) {
     // TODO: Implement Thermostat::doUpdate
     return -1;
 }

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -2,15 +2,6 @@
 #include "Ohmbrewer_Screen.h"
 
 /**
- * Adds the update function for the instance.
- */
-void Ohmbrewer::Thermostat::addUpdateFunction() {
-    String updateFunction;
-    getUpdateFunctionName(&updateFunction);
-    Spark.function<Ohmbrewer::Thermostat>(updateFunction.c_str(), &Ohmbrewer::Thermostat::update, this);
-}
-
-/**
  * The desired target temperature. Defaults to Celsius
  * @returns The target temperature in Celsius
  */
@@ -58,7 +49,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins) : Ohmbrewer::Equ
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -73,7 +64,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, const double tar
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -91,7 +82,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(0);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -111,7 +102,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* pins, int stopTime,
     _heatingElm = new HeatingElement(1,fakePins); // This isn't right
     _tempSensor = new TemperatureSensor(1, fakePins); // Neither is this
     _targetTemp = new Temperature(targetTemp);
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**
@@ -122,7 +113,7 @@ Ohmbrewer::Thermostat::Thermostat(const Ohmbrewer::Thermostat& clonee) : Ohmbrew
     _heatingElm = clonee.getElement();
     _tempSensor = clonee.getSensor();
     _targetTemp = clonee.getTargetTemp();
-    addUpdateFunction();
+    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -176,9 +176,10 @@ namespace Ohmbrewer {
             /**
              * Publishes updates to Ohmbrewer, etc.
              * This function is called by update().
+             * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the
@@ -200,6 +201,12 @@ namespace Ohmbrewer {
              * The desired operating temperature
              */
             Temperature* _targetTemp;
+
+        private:
+            /**
+             * Adds the update function for the instance.
+             */
+            void addUpdateFunction();
 
     };
 };

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -213,12 +213,6 @@ namespace Ohmbrewer {
              */
             Temperature* _targetTemp;
 
-        private:
-            /**
-             * Adds the update function for the instance.
-             */
-            void addUpdateFunction();
-
     };
 };
 

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -190,7 +190,7 @@ namespace Ohmbrewer {
              * @param args The argument string passed into the Particle Cloud
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -24,6 +24,17 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * The short-hand type name. Used for communicating with Ohmbrewer and disambiguating Equipment* pointers.
+             */
+            const static constexpr char* TYPE_NAME = "therm";
+
+            /**
+             * The Equipment Type
+             * @returns The Equipment type name
+             */
+            virtual const char* getType() const { return Thermostat::TYPE_NAME; };
+
+            /**
              * The desired target temperature. Defaults to Celsius
              * @returns The target temperature in Celsius
              */

--- a/lib/experimental/Ohmbrewer_Heating_Element.cpp
+++ b/lib/experimental/Ohmbrewer_Heating_Element.cpp
@@ -177,7 +177,7 @@ int Ohmbrewer::HeatingElement::doDisplay(Ohmbrewer::Screen *screen) {
  * This function is called by update().
  * @returns The time taken to run the method
  */
-int Ohmbrewer::HeatingElement::doUpdate() {
+int Ohmbrewer::HeatingElement::doUpdate(String args) {
     // TODO: Implement HeatingElement::doUpdate
     return -1;
 }

--- a/lib/experimental/Ohmbrewer_Heating_Element.cpp
+++ b/lib/experimental/Ohmbrewer_Heating_Element.cpp
@@ -173,7 +173,7 @@ int Ohmbrewer::HeatingElement::doDisplay(Ohmbrewer::Screen *screen) {
  * This function is called by update().
  * @returns The time taken to run the method
  */
-int Ohmbrewer::HeatingElement::doUpdate(String args) {
+int Ohmbrewer::HeatingElement::doUpdate(String* args) {
     // TODO: Implement HeatingElement::doUpdate
     return -1;
 }

--- a/lib/experimental/Ohmbrewer_Heating_Element.cpp
+++ b/lib/experimental/Ohmbrewer_Heating_Element.cpp
@@ -30,7 +30,6 @@ const int Ohmbrewer::HeatingElement::setVoltage(const int voltage) {
  */
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
     _voltage = 0;
-    _type = "heat";
 }
 
 /**
@@ -44,7 +43,6 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins) : Ohmbre
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stopTime,
                                           bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
     _voltage = 0;
-    _type = "heat";
 }
 
 /**
@@ -59,7 +57,6 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stop
 Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stopTime,
                                           bool state, String currentTask, int voltage) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask)  {
     _voltage = voltage;
-    _type = "heat";
 }
 
 /**
@@ -68,7 +65,6 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* pins, int stop
  */
 Ohmbrewer::HeatingElement::HeatingElement(const HeatingElement& clonee) : Ohmbrewer::Equipment(clonee) {
     _voltage = clonee.getVoltage();
-    _type = "heat";
 }
 
 /**

--- a/lib/experimental/Ohmbrewer_Heating_Element.h
+++ b/lib/experimental/Ohmbrewer_Heating_Element.h
@@ -140,7 +140,7 @@ namespace Ohmbrewer {
              * This function is called by update().
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/experimental/Ohmbrewer_Heating_Element.h
+++ b/lib/experimental/Ohmbrewer_Heating_Element.h
@@ -140,7 +140,7 @@ namespace Ohmbrewer {
              * This function is called by update().
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/experimental/Ohmbrewer_Pump.cpp
+++ b/lib/experimental/Ohmbrewer_Pump.cpp
@@ -176,7 +176,7 @@ int Ohmbrewer::Pump::doDisplay(Ohmbrewer::Screen *screen) {
  * This function is called by update().
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Pump::doUpdate(String args) {
+int Ohmbrewer::Pump::doUpdate(String* args) {
     // TODO: Implement Pump::doUpdate
     return -1;
 }

--- a/lib/experimental/Ohmbrewer_Pump.cpp
+++ b/lib/experimental/Ohmbrewer_Pump.cpp
@@ -28,7 +28,6 @@ const int Ohmbrewer::Pump::setSpeed(const int speed) {
  */
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, pins) {
     _speed = 0;
-    _type = "pump";
 }
 
 /**
@@ -42,7 +41,6 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins) : Ohmbrewer::Equipment(id, p
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask) {
     _speed = 0;
-    _type = "pump";
 }
 
 /**
@@ -57,7 +55,6 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
 Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
                       bool state, String currentTask, int speed) : Ohmbrewer::Equipment(id, pins, stopTime, state, currentTask)  {
     _speed = speed;
-    _type = "pump";
 }
 
 /**
@@ -66,7 +63,6 @@ Ohmbrewer::Pump::Pump(int id, std::list<int>* pins, int stopTime,
  */
 Ohmbrewer::Pump::Pump(const Pump& clonee) : Ohmbrewer::Equipment(clonee) {
     _speed = clonee.getSpeed();
-    _type = "pump";
 }
 
 /**

--- a/lib/experimental/Ohmbrewer_Pump.cpp
+++ b/lib/experimental/Ohmbrewer_Pump.cpp
@@ -180,7 +180,7 @@ int Ohmbrewer::Pump::doDisplay(Ohmbrewer::Screen *screen) {
  * This function is called by update().
  * @returns The time taken to run the method
  */
-int Ohmbrewer::Pump::doUpdate() {
+int Ohmbrewer::Pump::doUpdate(String args) {
     // TODO: Implement Pump::doUpdate
     return -1;
 }

--- a/lib/experimental/Ohmbrewer_Pump.h
+++ b/lib/experimental/Ohmbrewer_Pump.h
@@ -141,7 +141,7 @@ namespace Ohmbrewer {
              * This function is called by update().
              * @returns The time taken to run the method
              */
-            int doUpdate();
+            int doUpdate(String args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the

--- a/lib/experimental/Ohmbrewer_Pump.h
+++ b/lib/experimental/Ohmbrewer_Pump.h
@@ -141,7 +141,7 @@ namespace Ohmbrewer {
              * This function is called by update().
              * @returns The time taken to run the method
              */
-            int doUpdate(String args);
+            int doUpdate(String* args);
 
             /**
              * Reports which of the Rhizome's pins are occupied by the


### PR DESCRIPTION
Note, however, that the function names rely on the ID of the instance and we still haven't implemented a good way to set that in the case of compound classes (i.e. Thermostat and RIMS). For now, you'll need to keep that in mind. For example, if you were to create a RIMS and then a Pump (say, in `setup()`), you'll want to give the Pump an ID of '2' because the Pump associated with Spark.function `pump_1` is part of the RIMS object.
