### PR TITLE
Adds Temperature::toStrC and Temperature::toStrF for a standardized way to get the C-string representation of the Temperature (used, for example, in our display functions).

### DIFF
--- a/firmware/rhizome.ino
+++ b/firmware/rhizome.ino
@@ -53,7 +53,7 @@ void setup() {
 //    ((Ohmbrewer::TemperatureSensor*)sprouts.back())->getTemp()->set(42);
 //
 //    sprouts.push_back(new Ohmbrewer::TemperatureSensor( 2, new std::list<int>(1,1) ));
-//    ((Ohmbrewer::TemperatureSensor*)sprouts.back())->getTemp()->set(1337);
+//    ((Ohmbrewer::TemperatureSensor*)sprouts.back())->getTemp()->set(-20);
 
 // EX 2: A Thermostat
 //    sprouts.push_back(new Ohmbrewer::Thermostat( 1, new std::list<int>(1,0), 100 ));

--- a/lib/Ohmbrewer_Temperature.cpp
+++ b/lib/Ohmbrewer_Temperature.cpp
@@ -26,6 +26,24 @@ double Ohmbrewer::Temperature::get() const {
 }
 
 /**
+ * Fills a provided C-string buffer with the temperature, formatted for display.
+ * Note that this expects your buffer to be sufficiently large!
+ * @param buffer Buffer to fill with the formatted temperature in Celsius
+ */
+void Ohmbrewer::Temperature::toStrC(char* buffer, unsigned int width, unsigned precision) const {
+    sprintf(buffer, "%*.*f", width, precision, c());
+}
+
+/**
+ * Fills a provided C-string buffer with the temperature, formatted for display.
+ * Note that this expects your buffer to be sufficiently large!
+ * @param buffer Buffer to fill with the formatted temperature in Fahrenheit
+ */
+void Ohmbrewer::Temperature::toStrF(char* buffer, unsigned int width, unsigned precision) const {
+    sprintf(buffer, "%*.*f", width, precision, f());
+}
+
+/**
  * Sets the temperature from a Fahrenheit value
  * @param temp The temperature in Fahrenheit
  */

--- a/lib/Ohmbrewer_Temperature.h
+++ b/lib/Ohmbrewer_Temperature.h
@@ -33,6 +33,24 @@ namespace Ohmbrewer {
             double get() const;
 
             /**
+             * Fills a provided C-string buffer with the temperature, formatted for display.
+             * Note that this expects your buffer to be sufficiently large!
+             * @param buffer Buffer to fill with the formatted temperature in Celsius
+             * @param width Formatter width, defaults to 2
+             * @param precision Formatter precision, defaults to 2
+             */
+            void toStrC(char* buffer, unsigned int width = 6, unsigned precision = 2) const;
+
+            /**
+             * Fills a provided C-string buffer with the temperature, formatted for display.
+             * Note that this expects your buffer to be sufficiently large!
+             * @param buffer Buffer to fill with the formatted temperature in Celsius
+             * @param width Formatter width, defaults to 2
+             * @param precision Formatter precision, defaults to 2
+             */
+            void toStrF(char* buffer, unsigned int width = 2, unsigned precision = 2) const;
+
+            /**
              * Sets the temperature from a Fahrenheit value
              * @param temp The temperature in Fahrenheit
              */

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -139,10 +139,10 @@ int Ohmbrewer::TemperatureSensor::doWork() {
 int Ohmbrewer::TemperatureSensor::doDisplay(Ohmbrewer::Screen *screen) {
     unsigned long start = micros();
     char relay_id[2];
-    char tempStr [24];
+    char tempStr [10];
 
     sprintf(relay_id,"%d", _id);
-    sprintf(tempStr, "%2.2f", getTemp()->c());
+    getTemp()->toStrC(tempStr);
 
     // Print a fancy identifier
     screen->print(" [");
@@ -154,7 +154,7 @@ int Ohmbrewer::TemperatureSensor::doDisplay(Ohmbrewer::Screen *screen) {
     screen->print("]: ");
 
     // Print the temperature
-    screen->setTextColor(screen->YELLOW, screen->DEFAULT_BG_COLOR);
+    screen->setTextColor(screen->WHITE, screen->DEFAULT_BG_COLOR);
     screen->println(tempStr);
 
     screen->resetTextColor();

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -244,15 +244,15 @@ unsigned long Ohmbrewer::Thermostat::displayCurrentTemp(Ohmbrewer::Screen *scree
         color = screen->CYAN;
     }
 
-    displayTemp(getSensor()->getTemp()->c(), "Current: ", color, screen);
+    displayTemp(getSensor()->getTemp(), "Current: ", color, screen);
 
     // Show a warning if the Heating Element is active
     if(getElement()->isOn()) {
         screen->setTextColor(screen->RED, screen->DEFAULT_BG_COLOR);
-        screen->print("  ON");
+        screen->print(" ON");
     } else {
         screen->setTextColor(screen->BLACK, screen->DEFAULT_BG_COLOR);
-        screen->print("  ");
+        screen->print(" ");
         screen->writeBlock();
         screen->writeBlock();
     }
@@ -269,7 +269,7 @@ unsigned long Ohmbrewer::Thermostat::displayCurrentTemp(Ohmbrewer::Screen *scree
  */
 unsigned long Ohmbrewer::Thermostat::displayTargetTemp(Ohmbrewer::Screen *screen) {
     unsigned long start = micros();
-    displayTemp(getTargetTemp()->c(), "Target:  ", screen->YELLOW, screen);
+    displayTemp(getTargetTemp(), "Target:  ", screen->YELLOW, screen);
     screen->println("");
     return micros() - start;
 }
@@ -281,11 +281,10 @@ unsigned long Ohmbrewer::Thermostat::displayTargetTemp(Ohmbrewer::Screen *screen
  * @param color The color of the temperature text
  * @returns Time it took to run the function
  */
-unsigned long Ohmbrewer::Thermostat::displayTemp(double temp, char* label, uint16_t color, Ohmbrewer::Screen *screen) {
+unsigned long Ohmbrewer::Thermostat::displayTemp(const Temperature *temp, char* label, uint16_t color, Ohmbrewer::Screen *screen) {
     unsigned long start = micros();
-    char tempStr [24];
-
-    sprintf(tempStr, "%2.2f", temp);
+    char tempStr [10];
+    temp->toStrC(tempStr);
 
     // Print the label
     screen->resetTextColor();

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -182,7 +182,7 @@ namespace Ohmbrewer {
              * @param color The color of the temperature text
              * @returns Time it took to run the function
              */
-            unsigned long displayTemp(double temp, char* label, uint16_t color, Screen *screen);
+            unsigned long displayTemp(const Temperature *temp, char* label, uint16_t color, Screen *screen);
 
             /**
              * Publishes updates to Ohmbrewer, etc.


### PR DESCRIPTION
Resolves #12 .
