### PR TITLE
Gets the Publisher class working foreals, including an example in rhizome.ino (commented out).

### DIFF
--- a/firmware/rhizome.ino
+++ b/firmware/rhizome.ino
@@ -7,6 +7,7 @@
 #include "Ohmbrewer_Publisher.h"
 #include "Ohmbrewer_Thermostat.h"
 #include "Ohmbrewer_RIMS.h"
+// #include "Ohmbrewer_Publisher.h" // (*)
 
 // Kludge to allow us to use std::list - for now we have to undefine these macros.
 #undef min
@@ -37,6 +38,11 @@ Ohmbrewer::Screen screen = Ohmbrewer::Screen(D6, D7, A6, &sprouts);
 
 unsigned long lastUpdate = millis();
 
+// EX: Using a Publisher object. Other parts are marked with a (*). You'll probably want to use a different update
+//     rate (more like 30s instead of 10s) below.
+//Ohmbrewer::Publisher::publish_map_t pMap;
+//Ohmbrewer::Publisher* navi = new Ohmbrewer::Publisher(new String("fairies"), &pMap);
+
 /* ========================================================================= */
 /*  Main Functions                                                           */
 /* ========================================================================= */
@@ -44,7 +50,7 @@ unsigned long lastUpdate = millis();
  * Does any preliminary setup work before the Rhizome starts the operation loop.
  */
 void setup() {
-    Serial.begin(9600); // Enable serial for debugging messages
+    // Serial.begin(9600); // Enable serial for debugging messages
     String fakeTask = "fake";
 
     // Add our initial Equipment. We wouldn't necessarily do this, but it's useful for now.
@@ -77,23 +83,25 @@ void setup() {
     sprouts.push_back(new Ohmbrewer::Pump( 2, new std::list<int>(1,5) ));
 
     screen.initScreen();
+//    pMap[String("hey")] = String("listen!"); // (*)
 }
 
 /**
  * The meat of the program. Runs repeatedly until the Rhizome is powered off.
  */
 void loop() {
-//    if((millis() - lastUpdate) > 10000) {
-//        // Toggle the last relay every 10 seconds, for illustration.
-////        sprouts.back()->setState(sprouts.back()->isOff()); // The last HeatingElement
-////        ((Ohmbrewer::Thermostat*)sprouts.at(0))->getElement()
-////                                               ->setState(!((Ohmbrewer::Thermostat*)sprouts.at(0))->getElement()
-////                                                                                                  ->getState()); // The Thermostat's HeatingElement
-//        ((Ohmbrewer::RIMS*)sprouts.front())->getTube()
-//                                           ->getElement()
-//                                           ->toggleState();
-//        lastUpdate = millis();
-//    }
+    if((millis() - lastUpdate) > 10000) {
+        // Toggle the last relay every 10 seconds, for illustration.
+//        sprouts.back()->setState(sprouts.back()->isOff()); // The last HeatingElement
+//        ((Ohmbrewer::Thermostat*)sprouts.at(0))->getElement()
+//                                               ->setState(!((Ohmbrewer::Thermostat*)sprouts.at(0))->getElement()
+//                                                                                                  ->getState()); // The Thermostat's HeatingElement
+        ((Ohmbrewer::RIMS*)sprouts.front())->getTube()
+                                           ->getElement()
+                                           ->toggleState();
+//        navi->publish(); // (*)
+        lastUpdate = millis();
+    }
     screen.refreshDisplay();
 }
 

--- a/lib/Ohmbrewer_Publisher.cpp
+++ b/lib/Ohmbrewer_Publisher.cpp
@@ -9,13 +9,13 @@
 String Ohmbrewer::Publisher::toJSON() const {
     String returnVal = String("{");
 
-    for(publish_map_t::const_iterator itr = _data.begin(); itr != _data.end(); ++itr) {
+    for(publish_map_t::const_iterator itr = _data->begin(); itr != _data->end(); ++itr) {
         returnVal.concat(" \"");
         returnVal.concat(itr->first);
         returnVal.concat("\": \"");
         returnVal.concat(itr->second);
         returnVal.concat("\"");
-        if(itr->first != _data.rbegin()->first) {
+        if(itr->first != _data->rbegin()->first) {
             returnVal.concat(",");
         }
     }
@@ -31,7 +31,7 @@ String Ohmbrewer::Publisher::toJSON() const {
 int Ohmbrewer::Publisher::publish() const {
     unsigned long start = millis();
 
-    Spark.publish(_stream, this->toJSON(), 30, PRIVATE);
+    Spark.publish(*_stream, toJSON(), 30, PRIVATE);
 
     return start - millis();
 }
@@ -41,7 +41,7 @@ int Ohmbrewer::Publisher::publish() const {
  * @param stream The Particle cloud event stream to publish to
  * @param data A map of data to publish as a JSON.
  */
-Ohmbrewer::Publisher::Publisher(const String stream, const publish_map_t &data) {
+Ohmbrewer::Publisher::Publisher(String *stream, publish_map_t *data) {
     _stream = stream;
     _data = data;
 }
@@ -50,5 +50,5 @@ Ohmbrewer::Publisher::Publisher(const String stream, const publish_map_t &data) 
  * Destructor
  */
 Ohmbrewer::Publisher::~Publisher() {
-    // Nothing to do here...
+    delete _stream;
 }

--- a/lib/Ohmbrewer_Publisher.h
+++ b/lib/Ohmbrewer_Publisher.h
@@ -17,9 +17,9 @@ namespace Ohmbrewer {
 
     class Publisher {
 
-        typedef std::map<String, String> publish_map_t;
-
         public:
+
+            typedef std::map<String, String> publish_map_t;
 
             /**
              * The JSON representation of the provided keys and values.
@@ -40,7 +40,7 @@ namespace Ohmbrewer {
              * @param stream The Particle cloud event stream to publish to
              * @param data A map of data to publish as a JSON.
              */
-            Publisher(const String stream, const publish_map_t &todo);
+            Publisher(String *stream, publish_map_t *data);
             
             /**
              * Destructor
@@ -51,12 +51,12 @@ namespace Ohmbrewer {
             /**
              * The map of the JSON objects to publish, in order of presentation
              */
-            publish_map_t _data;
+            publish_map_t* _data;
 
             /**
              * The stream to publish to
              */
-            String _stream;
+            String* _stream;
     };
 };
 


### PR DESCRIPTION
The Publisher class provides a standardized wrapper around Spark.publish so we don't have to think too hard about sending our messages to Ohmbrewer. It should be used at the appropriate stage of doWork() to send those messages. For example, in a Relay-based class, you'd want to use a Publisher to send Ohmbrewer an update after you toggle the relay (whether due to a state change or due to reaching the stop time).
