### PR TITLE
Adds a router endpoint (/update) that provides a way to pass in Equipment updates.

### DIFF
--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -7,7 +7,7 @@
  */
 Ohmbrewer::Pump::Pump(int id, int pumpPin) : Ohmbrewer::Relay(id, pumpPin) {
 
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**FIXME
@@ -21,7 +21,7 @@ Ohmbrewer::Pump::Pump(int id, int pumpPin) : Ohmbrewer::Relay(id, pumpPin) {
 Ohmbrewer::Pump::Pump(int id, int pumpPin, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Relay(id, pumpPin, stopTime, state, currentTask) {
 
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -30,7 +30,7 @@ Ohmbrewer::Pump::Pump(int id, int pumpPin, int stopTime,
  */
 Ohmbrewer::Pump::Pump(const Pump& clonee) : Ohmbrewer::Relay(clonee) {
     // This has probably already been set, but maybe clonee is a more complicated child class...
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -15,7 +15,7 @@
 Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin ) : Ohmbrewer::Equipment(id) {
     //TODO currently only one probe at a time working.
     initRIMS(id, thermPins, pumpPin);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -30,7 +30,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin ) : Ohmbrew
 Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int stopTime,
                       bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
     initRIMS(id, thermPins, pumpPin);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -47,7 +47,7 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int stopTi
                       bool state, String currentTask, const double targetTemp) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
     initRIMS(id, thermPins, pumpPin);
     getTube()->setTargetTemp(targetTemp);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -59,7 +59,7 @@ Ohmbrewer::RIMS::RIMS(const Ohmbrewer::RIMS& clonee) : Ohmbrewer::Equipment(clon
     _tube = clonee.getTube();
     _recirc = clonee.getRecirculator();
 
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -167,9 +167,9 @@ void Ohmbrewer::RIMS::parseArgs(const String &argsStr, Ohmbrewer::Equipment::arg
 
     if(argsStr.length() > 0) {
         // FIXME These should probably be converted into private const variables
-        String tunSensorKey = String("tun_sensor_state");
+        String safetySensorKey = String("safety_sensor_state");
         String rPumpKey = String("r_pump_state");
-        String tubeKey = String("tube_params");
+        String thermKey = String("therm_params");
         char* params = new char[argsStr.length() + 1];
         strcpy(params, argsStr.c_str());
 
@@ -179,18 +179,18 @@ void Ohmbrewer::RIMS::parseArgs(const String &argsStr, Ohmbrewer::Equipment::arg
 
         // Save them to the map
         if(tunSensorState.length() > 0) {
-            result[tunSensorKey] = tunSensorState;
+            result[safetySensorKey] = tunSensorState;
         }
         if(rPumpState.length() > 0) {
             result[rPumpKey] = rPumpState;
         }
 
-        result[tubeKey] = argsStr.substring(tunSensorState.length() + rPumpState.length() + 2);
+        result[thermKey] = argsStr.substring(tunSensorState.length() + rPumpState.length() + 2);
 
         // Serial.println("Got these additional RIMS results: ");
         // Serial.println(tunSensorState);
         // Serial.println(rPumpState);
-        // Serial.println(result[tubeKey]);
+        // Serial.println(result[thermKey]);
 
         // Clear out that dynamically allocated buffer
         delete params;
@@ -453,19 +453,19 @@ int Ohmbrewer::RIMS::doUpdate(String &args, Ohmbrewer::Equipment::args_map_t &ar
 
     // If there are any remaining parameters
     if(args.length() > 0) {
-        String tunSensorKey = String("tun_sensor_state");
+        String safetySensorKey = String("safety_sensor_state");
         String rPumpKey = String("r_pump_state");
-        String tubeKey = String("tube_params");
+        String thermKey = String("therm_params");
 
         parseArgs(args, argsMap);
 
         // The remaining settings are optional/convenience parameters
-        if(argsMap.count(tunSensorKey) != 0) {
-            if(argsMap[tunSensorKey].equalsIgnoreCase("ON")) {
-                getTunSensor()->setState(true);
-            } else if(argsMap[tunSensorKey].equalsIgnoreCase("OFF")) {
-                getTunSensor()->setState(false);
-            } else if(argsMap[tunSensorKey].equalsIgnoreCase("--")) {
+        if(argsMap.count(safetySensorKey) != 0) {
+            if(argsMap[safetySensorKey].equalsIgnoreCase("ON")) {
+                getSafetySensor()->setState(true);
+            } else if(argsMap[safetySensorKey].equalsIgnoreCase("OFF")) {
+                getSafetySensor()->setState(false);
+            } else if(argsMap[safetySensorKey].equalsIgnoreCase("--")) {
                 // Do nothing. Intentional.
             } else {
                 // Do nothing. TODO: Should probably raise an error code...
@@ -485,9 +485,9 @@ int Ohmbrewer::RIMS::doUpdate(String &args, Ohmbrewer::Equipment::args_map_t &ar
         }
 
 
-        if(argsMap.count(tubeKey) != 0) {
+        if(argsMap.count(thermKey) != 0) {
             // Pass the remaining parameters down to the Tube (a Thermostat)
-            getTube()->doUpdate(argsMap[tubeKey], argsMap);
+            getTube()->doUpdate(argsMap[thermKey], argsMap);
         }
 
     }

--- a/lib/Ohmbrewer_Sprouts.h
+++ b/lib/Ohmbrewer_Sprouts.h
@@ -60,6 +60,29 @@ namespace Ohmbrewer {
         int addSprout(String argsStr);
 
         /**
+         * Updates Equipment by routing/delegating to the Equipment subclass's update() method.
+         *
+         * The argument string for this function must match the following format:
+         * TYPE,ID,UPDATE_STRING
+         * where
+         * TYPE matches the TYPE_NAME for the desired Equipment
+         * ID matches the ID of the desired Equipment
+         * UPDATE_STRING is a comma-delimited string that matches the format expected by the desired Equipment's class
+         *
+         * Both the ID and the UPDATE_STRING will be passed onto the update() method, but ID is validated within
+         * this method before update() is called as one more check against Hard Faults.
+         *
+         * @param argsStr The argument string passed via the Particle Cloud.
+         * @returns Equipment ID if successful,
+         *          (negative) error codes if unsuccessful:
+         *          -1 : Invalid Equipment Type
+         *          -2 : Invalid ID
+         *          -3 : Specified Equipment was not found in the list
+         *          -4 : Update failed
+         */
+        int updateSprout(String argsStr);
+
+        /**
          * Dynamically removes Equipment to the Rhizome.
          *
          * The argument string for this function must match the following format:

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -12,7 +12,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, Probe* probe) : Ohmbrewe
     _probe = probe;                 //For now all probes are all onewire
     _lastReading = new Temperature(-69);
     _lastReadTime = Time.now();
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -27,7 +27,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(int id,  Probe* probe, int stopT
     _probe = probe;
     _lastReading = new Temperature(-69);
     _lastReadTime = Time.now();
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -38,7 +38,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(const TemperatureSensor& clonee)
     _probe = clonee.getProbe();
     _lastReading = clonee.getTemp();
     _lastReadTime = Time.now();
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -12,7 +12,7 @@
  */
 Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins) : Ohmbrewer::Equipment(id) {
     initThermostat(id, thermPins);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -24,7 +24,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins) : Ohmbrewer
 Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, const double targetTemp) : Ohmbrewer::Equipment(id) {
     initThermostat(id, thermPins);
     _targetTemp->fromC(targetTemp);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -38,7 +38,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, const doubl
 Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, int stopTime,
                                   bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
     initThermostat(id, thermPins);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -55,7 +55,7 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, int stopTim
                                   const double targetTemp) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
     initThermostat(id, thermPins);
     _targetTemp->fromC(targetTemp);
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**
@@ -66,7 +66,7 @@ Ohmbrewer::Thermostat::Thermostat(const Ohmbrewer::Thermostat& clonee) : Ohmbrew
     _heatingElm = clonee.getElement();
     _tempSensor = clonee.getSensor();
     _targetTemp = clonee.getTargetTemp();
-    registerUpdateFunction();
+//    registerUpdateFunction();
 }
 
 /**


### PR DESCRIPTION
Should resolve #47 .

Gets our old update() methods working again, but now you send the request to `/update` and append the TYPE_NAME for the class to the front of the arguments string.

Example:

``` shell
args=rims,1,69,ON,1447474616,ON,OFF,100,ON,ON
```

Means that for RIMS 1, set:

```
current task: 69 (will end up matching a Task ID in the web app)
RIMS 1 State: ON
Stop Time: 1447474616 (Should be sometime in the future, but we don't check that at the moment)
Safety Sensor State: ON
R. Pump State: OFF
Target Temp: 100 (Celsius)
Thermostat Element State: ON
Thermostat Sensor State: ON
```

@azyth Take a look and let me know if we're good to go.
