### PR TITLE
Adds convenience functions to Publisher for fewer lines to do a publish().

### DIFF
--- a/firmware/rhizome.ino
+++ b/firmware/rhizome.ino
@@ -29,21 +29,26 @@
  */
 std::deque< Ohmbrewer::Equipment* > sprouts;
 
-//initializer Pin list
-//std::list<int> thermPins (1, 0);
-
 /**
  * The touchscreen object. Handles the display for the Rhizome.
  */
 Ohmbrewer::Screen screen = Ohmbrewer::Screen(D6, D7, A6, &sprouts);
 
 /**
+ * A timer for doing things every 15 seconds. Used by the sproutList below.
+ */
+Timer periodicUpdateTimer = Timer(15000, doPeriodicUpdates);
+
+/**
  * The managed list of sprouts
  * @todo Refactor how we handle Sprouts/SproutList so that the deque is encapsulated and Screen takes the list object
  */
-Ohmbrewer::Sprouts sproutList = Ohmbrewer::Sprouts(&sprouts, &screen);
+Ohmbrewer::Sprouts sproutList = Ohmbrewer::Sprouts(&sprouts, &screen, &periodicUpdateTimer);
 
 unsigned long lastUpdate = millis();
+
+//initializer Pin list
+//std::list<int> thermPins (1, 0);
 
 // EX: Using a Publisher object. Other parts are marked with a (*). You'll probably want to use a different update
 //     rate (more like 30s instead of 10s) below.
@@ -93,7 +98,7 @@ void setup() {
 //    ((Ohmbrewer::Thermostat*)sprouts.front())->setState(true); // Turn everything on.
 //    ((Ohmbrewer::RIMS*)sprouts.front())->getTube()->setTargetTemp(62.7);
 
-//TURN ON screen
+    // Turn on screen
     screen.initScreen();
 //    pMap[String("hey")] = String("listen!"); // (*)
 }
@@ -122,4 +127,15 @@ void loop() {
 
     //refresh the display
     screen.refreshDisplay();
+}
+
+/* ========================================================================= */
+/*  Other Global Functions                                                   */
+/* ========================================================================= */
+
+/**
+ * Delegator function that allows us to call the managed method for publishing periodic updates.
+ */
+void doPeriodicUpdates() {
+    sproutList.publishPeriodicUpdates();
 }

--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -100,8 +100,7 @@ const int Ohmbrewer::Equipment::setCurrentTask(String currentTask) {
  * @returns The Particle event stream the Equipment expects to publish to.
  */
 String Ohmbrewer::Equipment::getStream() const {
-    String stream = String("/");
-    stream.concat(this->getType());
+    String stream = String(this->getType());
     stream.concat("/");
     stream.concat(this->getID());
     return stream;

--- a/lib/Ohmbrewer_Publisher.cpp
+++ b/lib/Ohmbrewer_Publisher.cpp
@@ -47,6 +47,44 @@ Ohmbrewer::Publisher::Publisher(String *stream, publish_map_t *data) {
 }
 
 /**
+ * Constructor that initializes the data map internally.
+ * @param stream The Particle cloud event stream to publish to
+ */
+Ohmbrewer::Publisher::Publisher(String *stream) {
+    _stream = stream;
+    _data = new publish_map_t;
+}
+
+/**
+ * Constructor that adds the provided key/value pair to the Publisher's stream map.
+ * @param key A single key for data to publish as a JSON.
+ * @param value A single value for data to publish as a JSON.
+ */
+Ohmbrewer::Publisher::Publisher(String *stream, String key, String value) {
+    _stream = stream;
+    _data = new publish_map_t;
+    (*_data)[key] = value;
+}
+
+/**
+ * Constructor
+ * @param stream The Particle cloud event stream to publish to
+ * @param data A map of data to publish as a JSON.
+ * @return Whether the key/value pair was added successfully.
+ */
+bool Ohmbrewer::Publisher::add(String key, String value) {
+    (*_data)[key] = value;
+    return true;
+}
+
+/**
+ * Clears the internal data map
+ */
+void Ohmbrewer::Publisher::clear() {
+    (*_data).clear();
+}
+
+/**
  * Destructor
  */
 Ohmbrewer::Publisher::~Publisher() {

--- a/lib/Ohmbrewer_Publisher.h
+++ b/lib/Ohmbrewer_Publisher.h
@@ -41,6 +41,33 @@ namespace Ohmbrewer {
              * @param data A map of data to publish as a JSON.
              */
             Publisher(String *stream, publish_map_t *data);
+
+            /**
+             * Constructor that initializes the data map internally.
+             * @param stream The Particle cloud event stream to publish to
+             */
+            Publisher(String *stream);
+
+            /**
+             * Constructor
+             * @param stream The Particle cloud event stream to publish to
+             * @param key A single key for data to publish as a JSON.
+             * @param value A single value for data to publish as a JSON.
+             */
+            Publisher(String *stream, String key, String value);
+
+            /**
+             * Adds the provided key/value pair to the Publisher's stream map.
+             * @param key A single key for data to publish as a JSON.
+             * @param value A single value for data to publish as a JSON.
+             * @return Whether the key/value pair was added successfully.
+             */
+            bool add(String key, String value);
+
+            /**
+             * Clears the internal data map
+             */
+            void clear();
             
             /**
              * Destructor

--- a/lib/Ohmbrewer_Sprouts.h
+++ b/lib/Ohmbrewer_Sprouts.h
@@ -28,7 +28,7 @@ namespace Ohmbrewer {
          * @param sprouts A pointer to a pre-constructed deque object. Sprouts takes over responsibility of memory management for it.
          * @param screen A pointer to the Screen object. Sprouts does not handle its memory management.
          */
-        Sprouts(std::deque< Ohmbrewer::Equipment* > *sprouts, Ohmbrewer::Screen *screen);
+        Sprouts(std::deque< Ohmbrewer::Equipment* > *sprouts, Ohmbrewer::Screen *screen, Timer *put);
 
         /**
          * Destructor. Kills the internal deque.
@@ -96,18 +96,30 @@ namespace Ohmbrewer {
          */
         int removeSprout(String argsStr);
 
+        /**
+         * Publishes any periodic updates that need to be published.
+         * @see _periodicUpdateTimer
+         */
+        void publishPeriodicUpdates();
+
     protected:
 
-            /**
-             * Each Sprout is a logical collection of physical pins/relays that are connected
-             * to a single piece of Equipment.
-             */
-            std::deque< Equipment* >* _sprouts;
+        /**
+         * Each Sprout is a logical collection of physical pins/relays that are connected
+         * to a single piece of Equipment.
+         */
+        std::deque< Equipment* >* _sprouts;
 
-            /**
-             * The touchscreen object. Handles the display for the Rhizome.
-             */
-            Screen *_screen;
+        /**
+         * The touchscreen object. Handles the display for the Rhizome.
+         */
+        Screen *_screen;
+
+        /**
+         * The system-wide Timer for periodic updates. Kicks off every 15 seconds.
+         */
+        Timer* _periodicUpdateTimer;
+
 
     private:
 

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -1,6 +1,7 @@
 #include "Ohmbrewer_Temperature_Sensor.h"
 #include "Ohmbrewer_Screen.h"
 #include "Ohmbrewer_Onewire.h"
+#include "Ohmbrewer_Publisher.h"
 
 
 /**
@@ -207,9 +208,16 @@ int Ohmbrewer::TemperatureSensor::doUpdate(String &args, Ohmbrewer::Equipment::a
  * @param pins The list of physical pins that the TemperatureSensor is connected to.
  */
 void Ohmbrewer::TemperatureSensor::whichPins(std::list<int>* pins) {
-
     pins->push_back(_probe->getPin());
+}
 
-
+/**
+ * Publishes the latest reading
+ */
+void Ohmbrewer::TemperatureSensor::publishSensorReading() {
+    Publisher pub = Publisher(new String(getStream()),
+                              String("temperature"),
+                              String(getTemp()->c()));
+    pub.publish();
 }
 

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -157,6 +157,11 @@ namespace Ohmbrewer {
              */
             void whichPins(std::list<int>* pins);
 
+            /**
+             * Publishes the latest reading to the Particle event stream.
+             */
+            void publishSensorReading();
+
         protected:
             /**
              * Last temperature read by the sensor


### PR DESCRIPTION
Also adds a Timer-based function for reporting all the TemperatureSensor temperatures. Normally I don't mash this stuff together, but I needed a way to demonstrate the new functions worked and it kills two or three birds with one stone, so here we are.

Should resolve #33 and handle the first part of #37 .

Note that I had to do a janky delegation sort of thing to get the Timer to play nice with the class. From what I can tell, they didn't set up the Timer class the same way as Particle.function and there's no obvious way to pass in a reference to a particular instance of a class. I've tried every combination of &, *, ->, and lambda stuff I can think of, but no dice. [I've got a question about it on the Particle forums](https://community.particle.io/t/using-timer-in-a-class/17464), but I figure this will at least get us off the ground.

So the best I could do is instantiate a pointer to a Timer instance and pass it to the Sprouts object to manage (instead of instantiating it within Sprouts' constructor). When I instantiate the pointer, I provide it with a reference to a global function (like in the Particle docs) and that global function does the delegation. It's not pretty, I don't like it, but it works.

@azyth Good to go?
