### PR TITLE
Adds status publishing when the RIMS safety sensor kicks in and when the Thermostat reaches its target temp.

### DIFF
--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -264,9 +264,29 @@ int Ohmbrewer::RIMS::doWork() {
             if ( getSafetyTemp()->c() > getSafetySensor()->getTemp()->c() &&
                     !getTube()->getState() ) {
                 getTube()->setState(true); // turn on therm
+
+                // Notify Ohmbrewer that the Thermostat has been turned on.
+                Publisher pub = Publisher(new String(getStream()),
+                                          String("thermostat"),
+                                          String("ON"));
+                pub.add(String("last_read_time"),
+                        String(getTube()->getSensor()->getLastReadTime()));
+                pub.add(String("temperature"),
+                        String(getTube()->getSensor()->getTemp()->c()));
+                pub.publish();
             }
         }else if ( getTube()->getState() ){
             getTube()->setState(false);//PID should be able to handle this. TODO test to make sure
+
+            // Notify Ohmbrewer that the Thermostat has been turned off.
+            Publisher pub = Publisher(new String(getStream()),
+                                      String("thermostat"),
+                                      String("OFF"));
+            pub.add(String("last_read_time"),
+                    String(getTube()->getSensor()->getLastReadTime()));
+            pub.add(String("temperature"),
+                    String(getTube()->getSensor()->getTemp()->c()));
+            pub.publish();
         }
     }else{
         //IF RIMS OFF

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -311,6 +311,16 @@ int Ohmbrewer::Thermostat::doWork() {
         if (_heatingElm->getPowerPin() != -1) { // if powerPin enabled
             digitalWrite(_heatingElm->getPowerPin(), LOW); //turn it off too
         }
+
+        // Notify Ohmbrewer that the target temperature has been reached.
+        Publisher pub = Publisher(new String(getStream()),
+                                  String("msg"),
+                                  String("Target Temperature Reached."));
+        pub.add(String("last_read_time"),
+                String(getSensor()->getLastReadTime()));
+        pub.add(String("temperature"),
+                String(getSensor()->getTemp()->c()));
+        pub.publish();
     }
     if (!getState()){//if thermostat is turned off then turn off element.
         getElement()->setState(false);


### PR DESCRIPTION
Hold until #53 is merged. Should resolve what remains of #37 except the Stop Time-related status messages. I think we should handle those when we deal with #52 .

@azyth What do you think? (You may need to click on the actual commit to see what applies to this PR specifically...)
