### PR TITLE
Adds a RuntimeSettings class for keeping track of global settings and refactors the menu classes to remove settings tracking concerns and generally be more stateful.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(SOURCE_FILES
     ../lib/Ohmbrewer_Heating_Element.cpp
     ../lib/Ohmbrewer_Menu.h
     ../lib/Ohmbrewer_Menu.cpp
+    ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.h
+    ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.cpp
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_WiFi.h    
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_WiFi.cpp
     ../lib/Ohmbrewer_Onewire.cpp
@@ -29,6 +31,8 @@ set(SOURCE_FILES
     ../lib/Ohmbrewer_RIMS.cpp
     ../lib/Ohmbrewer_Screen.h
     ../lib/Ohmbrewer_Screen.cpp
+    ../lib/Ohmbrewer_Runtime_Settings.h
+    ../lib/Ohmbrewer_Runtime_Settings.cpp
     ../lib/Ohmbrewer_Sprouts.h
     ../lib/Ohmbrewer_Sprouts.cpp
     ../lib/Ohmbrewer_Temperature.h

--- a/firmware/rhizome.ino
+++ b/firmware/rhizome.ino
@@ -18,6 +18,7 @@
 #include "Ohmbrewer_RIMS.h"
 #include "Ohmbrewer_Onewire.h"
 #include "Ohmbrewer_Sprouts.h"
+#include "Ohmbrewer_Runtime_Settings.h"
 //external libraries
 #include "onewire.h"
 
@@ -36,8 +37,11 @@
 // to a single piece of Equipment.
 std::deque< Ohmbrewer::Equipment* > sprouts;
 
+// Various settings used during the run
+Ohmbrewer::RuntimeSettings settings = Ohmbrewer::RuntimeSettings();
+
 // The touchscreen object. Handles the display for the Rhizome.
-Ohmbrewer::Screen screen = Ohmbrewer::Screen(D6, D7, A6, &sprouts);
+Ohmbrewer::Screen screen = Ohmbrewer::Screen(D6, D7, A6, &sprouts, &settings);
 
 // A timer for doing things every 15 seconds. Used by the sproutList below.
 Timer periodicUpdateTimer = Timer(15000, doPeriodicUpdates);
@@ -64,9 +68,9 @@ void setup() {
 	screen.initScreen();
 	
 	//Turn on for debugging
-	//Serial.begin(9600);
+	Serial.begin(9600);
 	
-	delay(1000);
+//	delay(1000);
 }
 
 /**
@@ -90,13 +94,13 @@ void loop() {
  */
 void doPeriodicUpdates() {
 	//Do not attempt to publish updates if disconnected from the cloud
-		if(!Particle.connected()){
-				//TODO: Define WiFi Address location properly
-				if(EEPROM.read(1) == 0x01){
-				//WiFi is not connected and should be - attempt to connect
-				Particle.connect();
-		}
+    if(!Particle.connected()){
+        // TODO: Define WiFi Address location properly
+        if(EEPROM.read(1) == Ohmbrewer::RuntimeSettings::EEPROM_WIFI_STATUS_OFF){
+            //WiFi is not connected and should be - attempt to connect
+            Particle.connect();
+        }
 	} else {
-		sproutList.publishPeriodicUpdates();
-	}
+        sproutList.publishPeriodicUpdates();
+    }
 }

--- a/lib/Ohmbrewer_Menu.cpp
+++ b/lib/Ohmbrewer_Menu.cpp
@@ -1,5 +1,109 @@
 #include "Ohmbrewer_Menu.h"
 #include "Ohmbrewer_Screen.h"
+#include "Ohmbrewer_Runtime_Settings.h"
 
+/**
+ * Constructors
+ * @param screen A pointer to the Screen object.
+ * @param settings A pointer to the RuntimeSettings object.
+ */
+Ohmbrewer::Menu::Menu(Ohmbrewer::Screen *screen, Ohmbrewer::RuntimeSettings *settings) {
+    _screen = screen;
+    _settings = settings;
+}
 
+/**
+ * Destructor
+ */
+Ohmbrewer::Menu::~Menu() {
+    // Do nothing
+}
 
+/**
+ * Draws the menu to the Rhizome's display.
+ */
+void Ohmbrewer::Menu::displayMenu() {
+    // Disabled by default
+}
+
+/**
+ * Takes action when the menu button is pressed in the Menu Screen
+ * The precise action will be determined by the individual menu screens
+ */
+void Ohmbrewer::Menu::menuPressed() {
+    // Disabled by default
+}
+
+/**
+ * Takes action when the select button is pressed in the Menu Screen
+ * The precise action will be determined by the individual menu screens
+ */
+void Ohmbrewer::Menu::selectPressed() {
+    // Disabled by default
+}
+
+/**
+ * Takes action when the plus button is pressed in the WiFi Menu Screen
+ * @returns The time taken to run the method
+ */
+void Ohmbrewer::Menu::plusPressed(){
+    if(_selectedOption < (options.size() - 1)){
+        _selectedOption++;
+    } else {
+        _selectedOption = 0;
+    }
+}
+
+/**
+* Takes action when the minus button is pressed in the WiFi Menu Screen
+* @returns The time taken to run the method
+*/
+void Ohmbrewer::Menu::minusPressed(){
+    if(_selectedOption > 0){
+        _selectedOption--;
+    } else {
+        _selectedOption = (options.size() - 1);
+    }
+}
+
+/**
+ * Transitions to the next level up (parent) in the menu tree
+ * @returns The time taken to run the method
+ */
+void Ohmbrewer::Menu::goUp() {
+    _screen->setCurrentMenu(_parent);
+}
+
+/**
+ * Transitions to the next level down via a specified child in the menu tree
+ * @param child The index of the child to transition to within the menu's descendants list
+ * @returns The time taken to run the method
+ */
+void Ohmbrewer::Menu::goDownTo(const int child) {
+    _screen->setCurrentMenu(_children[child]);
+}
+
+/**
+ * Sets the parent of this menu
+ * @param parent The parent to set
+ */
+void Ohmbrewer::Menu::setParent(Menu* parent) {
+    _parent = parent;
+}
+
+/**
+ * Adds a child menu below this menu
+ * @param child The menu to add
+ */
+void Ohmbrewer::Menu::addChild(Menu* child) {
+    child->setParent(this);
+    _children.push_back(child);
+}
+
+/**
+ * True if this is the top-most menu in the tree
+ * @returns True if this is the Home menu, False otherwise
+ */
+bool Ohmbrewer::Menu::isHome() {
+    return _parent == nullptr; // Could just return _parent, but let's be explicit
+}

--- a/lib/Ohmbrewer_Menu.h
+++ b/lib/Ohmbrewer_Menu.h
@@ -7,70 +7,106 @@
 #define OHMBREWER_MENU_H
 
 // Kludge to allow us to use std::vector - for now we have to undefine these macros.
+#undef min
+#undef max
 #undef swap
-#include "application.h"
+
 #include <vector>
+#include "application.h"
+#include "Ohmbrewer_Runtime_Settings.h"
+#include "Ohmbrewer_Screen.h"
 
 
 namespace Ohmbrewer {
 
     //forward declaration
     class Screen;
-    
+
     class Menu {
     
         public:
-        
-        static const int      MENU_WIFI_ADDR = 1;
+
+        /**
+         * Constructors
+         * @param screen A pointer to the Screen object.
+         * @param settings A pointer to the RuntimeSettings object.
+         */
+        Menu(Screen *screen, RuntimeSettings *settings);
+
+        /**
+         * Destructor
+         */
+        virtual ~Menu();
         
         /**
-        * Constructors
-        * @param screen A pointer to the Screen object.
-        */
-        
-        //Menu(Ohmbrewer::Screen *screen);
-        
-        /**
-        * Draws the menu to the Rhizome's display.
-        * @returns The time taken to run the method
-        */      
-        
-        virtual int displayMenu();
+         * Draws the menu to the Rhizome's display.
+         */
+        virtual void displayMenu();
         
         /**
          * Takes action when the plus button is pressed in the Menu Screen
          * The precise action will be determined by the individual menu screens
-         * @returns The time taken to run the method
          */
-        virtual int plusPressed();
+        virtual void plusPressed();
+
         /**
          * Takes action when the plus button is pressed in the Menu Screen
          * The precise action will be determined by the individual menu screens
-         * @returns The time taken to run the method
          */
-        virtual int minusPressed();
+        virtual void minusPressed();
         
         /**
          * Takes action when the menu button is pressed in the Menu Screen
          * The precise action will be determined by the individual menu screens
-         * @returns The time taken to run the method
          */
-        virtual int menuPressed();
+        virtual void menuPressed();
         
         /**
          * Takes action when the select button is pressed in the Menu Screen
          * The precise action will be determined by the individual menu screens
-         * @returns The time taken to run the method
          */     
-        virtual int selectPressed();
+        virtual void selectPressed();
+
+        /**
+         * Transitions to the next level up (parent) in the menu tree
+         */
+        void goUp();
+
+        /**
+         * Transitions to the next level down via a specified child in the menu tree
+         * @param child The index of the child to transition to within the menu's descendants list
+         */
+        void goDownTo(const int child);
+
+        /**
+         * Sets the parent of this menu
+         * @param parent The parent to set
+         */
+        void setParent(Menu* parent);
+
+        /**
+         * Adds a child menu below this menu
+         * @param child The menu to add
+         */
+        void addChild(Ohmbrewer::Menu* child);
+
+        /**
+         * True if this is the top-most menu in the tree
+         * @returns True if this is the Home menu, False otherwise
+         */
+        bool isHome();
         
         protected:
         
-        
         /**
-        * The touchscreen object. Handles the display for the Rhizome.
-        */
-        Screen * _screen;
+         * The touchscreen object. Handles the display for the Rhizome.
+         */
+        Screen* _screen;
+
+        /**
+         * The touchscreen object. Handles the display for the Rhizome.
+         */
+        RuntimeSettings* _settings;
         
         /**
         * The list of options for this particular menu screen.
@@ -80,8 +116,17 @@ namespace Ohmbrewer {
         /**
         * The currently selected option.
         */
-        int selectedOption;
-    
+        unsigned int _selectedOption;
+
+        /**
+         * The menu above this menu in the menu tree
+         */
+        Menu* _parent;
+
+        /**
+         * Zero or more menus reachable from this menu below this menu on the menu tree
+         */
+        std::vector<Menu*> _children;
     };
 
 

--- a/lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.cpp
+++ b/lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.cpp
@@ -1,0 +1,29 @@
+#include "Ohmbrewer_Menu_Home.h"
+#include "Ohmbrewer_Runtime_Settings.h"
+#include "Ohmbrewer_Screen.h"
+#include "Ohmbrewer_Menu.h"
+
+/**
+ * Constructors
+ * @param screen A pointer to the Screen object.
+ * @param settings A pointer to the RuntimeSettings object.
+ */
+Ohmbrewer::MenuHome::MenuHome(Ohmbrewer::Screen *screen, Ohmbrewer::RuntimeSettings *settings) : Ohmbrewer::Menu::Menu(screen, settings) {
+    // Nothing new to do
+}
+
+/**
+ * Draws the menu to the Rhizome's display.
+ * @todo Refactor the display drawing stuff that's currently in Screen into this
+ */
+void Ohmbrewer::MenuHome::displayMenu() {
+    // Do nothing for now...
+}
+
+/**
+ * Takes action when the menu button is pressed in the Menu Screen
+ * The precise action will be determined by the individual menu screens
+ */
+void Ohmbrewer::MenuHome::menuPressed() {
+    _screen->setCurrentMenu(_children[WIFI_MENU]);
+}

--- a/lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.h
+++ b/lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Home.h
@@ -3,8 +3,8 @@
  * Rhizome is part of the Ohmbrewer project (see http://ohmbrewer.org for details).
  */
 
-#ifndef OHMBREWER_MENU_WIFI_H
-#define OHMBREWER_MENU_WIFI_H
+#ifndef OHMBREWER_MENU_HOME_H
+#define OHMBREWER_MENU_HOME_H
 
 // Kludge to allow us to use std::vector - for now we have to undefine these macros.
 #undef swap
@@ -17,24 +17,31 @@
 
 namespace Ohmbrewer {
 
-    class MenuWiFi : public Menu {
+    class MenuHome : public Menu {
     
         public:
+
+        /* Constants */
+        static const int WIFI_MENU = 0;
+
+        /* Methods */
 
         /**
          * Constructors
          * @param screen A pointer to the Screen object.
+         * @param settings A pointer to the RuntimeSettings object.
          */
-        MenuWiFi(Screen *screen, RuntimeSettings *settings);
+        MenuHome(Screen *screen, RuntimeSettings *settings);
 
         /**
          * Destructor
          */
-        virtual ~MenuWiFi() {};
+        virtual ~MenuHome() {};
         
         /**
-        * Draws the menu to the Rhizome's display.
-        */      
+         * Draws the menu to the Rhizome's display.
+         * @todo Refactor the display drawing stuff that's currently in Screen into this
+         */
         void displayMenu();
         
         /**
@@ -42,14 +49,6 @@ namespace Ohmbrewer {
          * The precise action will be determined by the individual menu screens
          */
         void menuPressed();
-        
-        /**
-         * Takes action when the select button is pressed in the Menu Screen
-         * The precise action will be determined by the individual menu screens
-         */
-        void selectPressed();
-            
-    
     };
 
 

--- a/lib/Ohmbrewer_Runtime_Settings.cpp
+++ b/lib/Ohmbrewer_Runtime_Settings.cpp
@@ -1,0 +1,71 @@
+#include "Ohmbrewer_Runtime_Settings.h"
+
+/**
+ * Constructor.
+ * All settings will be pulled from EEPROM, if supported
+ */
+Ohmbrewer::RuntimeSettings::RuntimeSettings() {
+
+    // Figure out what was in EEPROM and assign it to the appropriate variables
+    int eepromWifiStatus = readEEPROMWifiStatus();
+
+    // If the WiFi Status has never been written to EEPROM, we'll want to do so now.
+    // Otherwise, let's save a write for later.
+    if(eepromWifiStatus == -1) {
+        _wifiStatus = true;
+        writeEEPROMWifiStatus();
+    } else {
+        _wifiStatus = eepromWifiStatus;
+    }
+}
+
+/**
+ * Constructor
+ * Settings that are not provided will be pulled from EEPROM, if supported
+ * @param wifiStatus Whether the Wifi is ON (or OFF). True => ON, False => OFF.
+ */
+Ohmbrewer::RuntimeSettings::RuntimeSettings(bool wifiStatus) {
+    _wifiStatus = wifiStatus;
+    writeEEPROMWifiStatus();
+}
+
+/**
+ * Writes the current Wifi Status out to EEPROM
+ * @param status Whether the Wifi is ON (or OFF). True => ON, False => OFF
+ */
+const void Ohmbrewer::RuntimeSettings::writeEEPROMWifiStatus() {
+    EEPROM.write(WIFI_STATUS_ADDR, (_wifiStatus ? EEPROM_WIFI_STATUS_ON : EEPROM_WIFI_STATUS_OFF));
+}
+
+/**
+ * Sets the Wifi status and immediately saves to EEPROM. True => On, False => Off
+ * @param status Whether the Wifi is ON (or OFF). True => ON, False => OFF
+ */
+const void Ohmbrewer::RuntimeSettings::setWifiStatusAndSave(const bool status) {
+    setWifiStatus(status);
+
+    // Only write when actually necessary
+    if(readEEPROMWifiStatus() != _wifiStatus) {
+        writeEEPROMWifiStatus();
+    }
+}
+
+/**
+ * Reads the current Wifi Status from EEPROM.
+ * Because the value could potentially have never been set, this is more complex than a simple bool.
+ * @returns The saved Wifi Status. True => 1, False => 0, Unset/Other => -1
+ */
+const int Ohmbrewer::RuntimeSettings::readEEPROMWifiStatus() {
+    // WiFi setting is stored at addr 1
+    uint8_t value = EEPROM.read(WIFI_STATUS_ADDR);
+
+    // Compare against possible results
+    if (value == EEPROM_WIFI_STATUS_OFF) {
+        return 0;
+    } else if (value == EEPROM_WIFI_STATUS_ON) {
+        return 1;
+    }
+
+    // Don't know what to make of the result
+    return -1;
+}

--- a/lib/Ohmbrewer_Runtime_Settings.h
+++ b/lib/Ohmbrewer_Runtime_Settings.h
@@ -1,0 +1,99 @@
+/**
+ * This library provides the Runtime Settings base class of the Rhizome PID/equipment controller.
+ * Rhizome is part of the Ohmbrewer project (see http://ohmbrewer.org for details).
+ */
+
+#ifndef OHMBREWER_RUNTIME_SETTINGS_H
+#define OHMBREWER_RUNTIME_SETTINGS_H
+
+#include "application.h"
+
+
+namespace Ohmbrewer {
+
+    class RuntimeSettings {
+    
+        public:
+
+        /* Constants */
+
+        /**
+         * Where the WiFi setting is stored
+         */
+        static const int WIFI_STATUS_ADDR = 1;
+        static const int EEPROM_WIFI_STATUS_OFF = 0x01;
+        static const int EEPROM_WIFI_STATUS_ON = 0x00;
+
+        /* Methods */
+
+        /**
+         * Constructor.
+         * All settings will be pulled from EEPROM, if supported
+         */
+        RuntimeSettings();
+
+        /**
+         * Constructor
+         * Settings that are not provided will be pulled from EEPROM, if supported
+         * @param wifiStatus Whether the Wifi is ON (or OFF). True => ON, False => OFF.
+         */
+        RuntimeSettings(bool wifiStatus);
+
+        /**
+         * The Wifi status. True => On, False => Off
+         * @returns True => On, False => Off
+         */
+        bool getWifiStatus() const { return _wifiStatus; };
+
+        /**
+         * Sets the Wifi status. True => On, False => Off
+         * @param status Whether the Wifi is ON (or OFF). True => ON, False => OFF
+         */
+        const void setWifiStatus(const bool status) { _wifiStatus = status; };
+
+        /**
+         * Sets the Wifi status and immediately saves to EEPROM. True => On, False => Off
+         * @param status Whether the Wifi is ON (or OFF). True => ON, False => OFF
+         */
+        const void setWifiStatusAndSave(const bool status);
+
+        /**
+         * The Wifi status. True => On, False => Off
+         * @returns True => On, False => Off
+         */
+        bool isWifiOn() const {return getWifiStatus();};
+
+        /**
+         * The Wifi status. True => On, False => Off
+         * @returns True => On, False => Off
+         */
+        bool isWifiOff() const {return !getWifiStatus();};
+
+    protected:
+
+        /**
+         * Whether the WiFi should be on (true) or off (false)
+         */
+        bool _wifiStatus;
+
+    private:
+
+        /**
+         * Writes the current Wifi Status out to EEPROM
+         * @param status Whether the Wifi is ON (or OFF). True => ON, False => OFF
+         */
+        const void writeEEPROMWifiStatus();
+
+        /**
+         * Reads the current Wifi Status from EEPROM.
+         * Because the value could potentially have never been set, this is more complex than a simple bool.
+         * @returns The saved Wifi Status. True => 1, False => 0, Unset/Other => -1
+         */
+        const int readEEPROMWifiStatus();
+
+    };
+
+
+}
+
+#endif

--- a/lib/Ohmbrewer_Screen.cpp
+++ b/lib/Ohmbrewer_Screen.cpp
@@ -6,6 +6,9 @@
 #include "Ohmbrewer_Relay.h"
 #include "Ohmbrewer_Thermostat.h"
 #include "Ohmbrewer_RIMS.h"
+#include "Ohmbrewer_Runtime_Settings.h"
+#include "Ohmbrewer_Menu_WiFi.h"
+#include "Ohmbrewer_Menu_Home.h"
 
 
 /**
@@ -14,16 +17,24 @@
 Ohmbrewer::Screen::Screen(uint8_t CS,
                           uint8_t RS,
                           uint8_t RST,
-                          std::deque< Ohmbrewer::Equipment* >* sprouts) : Adafruit_ILI9341(CS, RS, RST) {
+                          std::deque< Ohmbrewer::Equipment* >* sprouts,
+                          Ohmbrewer::RuntimeSettings *settings) : Adafruit_ILI9341(CS, RS, RST) {
     _sprouts = sprouts;
-    /** 
-    *  For better pressure precision, we need to know the resistance
-    *  between X+ and X- Use any multimeter to read it
-    *  Using value of 285 ohms across the X plate
-    */  
-    ts = new TouchScreen(XP, YP, XM, YM, 285);
-    menu = new Ohmbrewer::Menu_WiFi(this);
-    wiFiMenuUp = false;
+    _settings= settings;
+
+    /*
+     *  For better pressure precision, we need to know the resistance
+     *  between X+ and X- Use any multimeter to read it
+     *  Using value of 285 ohms across the X plate
+     */
+    _ts = new TouchScreen(XP, YP, XM, YM, 285);
+
+    // Build the menu tree
+    _homeMenu = new MenuHome(this, settings);
+    _homeMenu->addChild(new MenuWiFi(this, settings));
+
+    // Set the current menu to be the home menu
+    _currentMenu = _homeMenu;
 }
 
 /**
@@ -117,37 +128,44 @@ unsigned long Ohmbrewer::Screen::refreshDisplay() {
 
     displayHeader();
 
-    displayRIMS();
-    displayThermostats();
-
-    // We want to show a different border for the Manual Relays section if there were any Thermostats or RIMS
-    int thermostats = 0;
-    int rims = 0;
-    for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
-        if (strcmp((*itr)->getType(), Thermostat::TYPE_NAME) == 0) {
-            thermostats++;
-        }
-        if (strcmp((*itr)->getType(), RIMS::TYPE_NAME) == 0) {
-            rims++;
-        }
-    }
-
-    if((thermostats + rims) > 2) {
-        // Don't print the header line
-    } else if((thermostats + rims) > 0) {
-        // We've got 1-2 Thermostats or RIMS, so print a thin line
-        print("--------------------");
+    if(!_currentMenu->isHome()) {
+        _currentMenu->displayMenu();
     } else {
-        // There aren't any Thermostats or RIMS, so print a fat line
-        print("====================");
-    }
+        // TODO: Shift this stuff into MenuHome#displayMenu()
 
-    displayManualRelays();
-//    // These are the old, single type displays, for easy debugging.
-//    displayTemps();
-//    displayRelays();
-//    displayHeatingElements();
-//    displayPumps();
+        displayRIMS();
+        displayThermostats();
+
+        // We want to show a different border for the Manual Relays section if there were any Thermostats or RIMS
+        int thermostats = 0;
+        int rims = 0;
+        for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
+            if (strcmp((*itr)->getType(), Thermostat::TYPE_NAME) == 0) {
+                thermostats++;
+            }
+            if (strcmp((*itr)->getType(), RIMS::TYPE_NAME) == 0) {
+                rims++;
+            }
+        }
+
+        if((thermostats + rims) > 2) {
+            // Don't print the header line
+        } else if((thermostats + rims) > 0) {
+            // We've got 1-2 Thermostats or RIMS, so print a thin line
+            print("--------------------");
+        } else {
+            // There aren't any Thermostats or RIMS, so print a fat line
+            print("====================");
+        }
+
+        displayManualRelays();
+    //    // These are the old, single type displays, for easy debugging.
+    //    displayTemps();
+    //    displayRelays();
+    //    displayHeatingElements();
+    //    displayPumps();
+
+    }
 
     // 500 seems like a good refresh delay
     delay(500);
@@ -382,26 +400,20 @@ unsigned long Ohmbrewer::Screen::captureButtonPress() {
     char status [40];
     
     // a point object holds x y and z coordinates
-    TSPoint p = ts->getPoint();
+    TSPoint p =_ts->getPoint();
     //According to Particle forums, the read below is necessary to get touch to work on Photon
-    ts->readTouchY();
+    _ts->readTouchY();
 
   
     // we have some minimum pressure we consider 'valid'
     // pressure of 0 means no pressing!
-    if (p.z < MINPRESSURE || p.z > MAXPRESSURE) {
+    if (p.z > MINPRESSURE || p.z < MAXPRESSURE) {
         displayStatusUpdate("                                        ");
         return micros() - start;
     }
-    
-    // Get out of here if no one is touching
-    if (p.z < 0) {
-        displayStatusUpdate("                                        ");
-        return micros() - start;
-    }
-    
+
     // Scale from ~0->1000 to tft.width using the calibration #'s
-    p.x = map(p.x, TS_MINX, TS_MAXX, 0, width()) - 35; // This -35 is a dirty hack. We need to fix the scaling to get this working without it.
+    p.x = map(p.x, TS_MINX, TS_MAXX, 0, width()); // This -35 is a dirty hack. We need to fix the scaling to get this working without it.
     p.y = map(p.y, TS_MINY, TS_MAXY, 0, height());
     
     // Each of these should pad out with spaces on the right
@@ -415,30 +427,28 @@ unsigned long Ohmbrewer::Screen::captureButtonPress() {
 
         if (p.x > 0 && p.x <= BUTTONSIZE) {
             // +                 12345678901234567890
-            menu->plusPressed();
+            _currentMenu->plusPressed();
             statusUpdate.concat("Pressing +!         ");
+//            Serial.println("Pressing +!    ");
         } else if (p.x > BUTTONSIZE && p.x <= BUTTONSIZE*2) {
             // -
-            menu->minusPressed();
+            _currentMenu->minusPressed();
             statusUpdate.concat("Pressing -!         ");
+//            Serial.println("Pressing -!    ");
         } else if (p.x > BUTTONSIZE*2 && p.x <= BUTTONSIZE*3) {
-        
             // Menu
-            if(!wiFiMenuUp) {
-                wiFiMenuUp = true;
-                menu->displayMenu();      
-            } else {
-                wiFiMenuUp = false;
-                reinitScreen();
-            }
+            _currentMenu->menuPressed();
             statusUpdate.concat("Pressing Menu!      ");
+//            Serial.println("Pressing Menu!    ");
         } else if (p.x > BUTTONSIZE*3 && p.x <= BUTTONSIZE*4) {
             // Select
-            menu->selectPressed();
+            _currentMenu->selectPressed();
             statusUpdate.concat("Pressing Select!    ");
+//            Serial.println("Pressing Select!    ");
         } else {
             // Nothing. Weird.
             statusUpdate.concat("                    ");
+//            Serial.println("Pressing Nothing!    ");
         }
         
         // Barf it onto the display...
@@ -446,10 +456,27 @@ unsigned long Ohmbrewer::Screen::captureButtonPress() {
         displayStatusUpdate(status);
     }
     
-    //Serial.print("X = "); Serial.print(p.x);
-    //Serial.print("\tY = "); Serial.print(p.y);
-    //Serial.print("\tPressure = "); Serial.println(p.z);
-    
+//    Serial.print("X = "); Serial.print(p.x);
+//    Serial.print("\tY = "); Serial.print(p.y);
+//    Serial.print("\tPressure = "); Serial.println(p.z);
+
+    // Delay 1 second to allow for some debounce
+    delay(1000);
     return micros() - start;
 }
 
+/**
+ * Moves the Current Menu pointer
+ * @param nextMenu The menu to move to
+ */
+void Ohmbrewer::Screen::setCurrentMenu(Ohmbrewer::Menu* nextMenu) {
+    _currentMenu = nextMenu;
+}
+
+/**
+ * Returns the Current Menu pointer
+ * @returns The current menu
+ */
+Ohmbrewer::Menu* Ohmbrewer::Screen::getCurrentMenu() const {
+    return _currentMenu;
+}

--- a/lib/Ohmbrewer_Screen.h
+++ b/lib/Ohmbrewer_Screen.h
@@ -16,11 +16,13 @@
 #include "Adafruit_ILI9341.h"
 #include "application.h"
 #include "Touch_4Wire.h"
-#include "Ohmbrewer_Menu_WiFi.h"
+#include "Ohmbrewer_Runtime_Settings.h"
+#include "Ohmbrewer_Menu.h"
 
 namespace Ohmbrewer {
 
     class Equipment;
+    class Menu;
 
     // TODO: Add a member object to Ohmbrewer::Screen that represents the capacitive touch capabilities
     // (e.g. an instance of Adafruit Touch 4Wire TouchScreen)
@@ -51,13 +53,13 @@ namespace Ohmbrewer {
             static const int      TS_MINY = 300;
             static const int      TS_MAXX = 3650;
             static const int      TS_MAXY = 3650;
-            static const int      MINPRESSURE = 50;
             static const int      MAXPRESSURE = 4000;
+            static const int      MINPRESSURE = 50;
 
             /**
              * CONSTRUCTOR
              */
-            Screen(uint8_t CS, uint8_t RS, uint8_t RST, std::deque< Ohmbrewer::Equipment* >* sprouts);
+            Screen(uint8_t CS, uint8_t RS, uint8_t RST, std::deque< Ohmbrewer::Equipment* >* sprouts, Ohmbrewer::RuntimeSettings *settings);
 
             /**
              * Resets the foreground and background text colors to the defaults above.
@@ -172,34 +174,44 @@ namespace Ohmbrewer {
              * @returns Time it took to run the function
              */
             unsigned long captureButtonPress();
-            
-            /**
-             * Accessor for WiFi Setting from WiFi Menu
-             * @returns Boolean representing whether WiFi should be connected or not
-             */
-            bool getWiFiSetting();
 
+            /**
+             * Moves the Current Menu pointer
+             * @param nextMenu The menu to move to
+             */
+            void setCurrentMenu(Menu* nextMenu);
+
+            /**
+             * Moves the Current Menu pointer
+             * @param nextMenu The menu to move to
+             */
+            Menu* getCurrentMenu() const;
 
         private:
             /**
              * Pointer to the global Sprouts list
              */
-            std::deque< Ohmbrewer::Equipment* >* _sprouts;
+            std::deque< Equipment* >* _sprouts;
+
+            /**
+             * Pointer to the global Sprouts list
+             */
+            RuntimeSettings* _settings;
             
             /** 
-            *  The touchscreen object used to check for taps
-            *    on the screen
-                        */
-            TouchScreen * ts;
+             *  The touchscreen object used to check for taps on the screen
+             */
+            TouchScreen* _ts;
             
             /**
-             * Pointer to the menu structure
+             * Pointer to the current menu
              */            
-            Ohmbrewer::Menu * menu;
-            
-            //variable to keep track of whether the WiFi Menu is open or not
-            //TODO: replace with data structure to keep track of menu location
-            bool wiFiMenuUp;
+            Menu* _currentMenu;
+
+            /**
+             * Pointer to the home menu, for quickly jumping to home
+             */
+            Menu* _homeMenu;
 
     };
 


### PR DESCRIPTION
@nischalvasant This is basically what I was talking about yesterday. It did end up being a bit much, but I think that's because the original task should have probably been split up a bit (i.e. a PR for just poking something, a PR for saving settings to EEPROM, etc.)

Unfortunately, even though this compiles, I can't seem to get it to work on my Rhizomes. The touchscreen always seems to be pulling a coordinate at the far corner of the screen. Between this and the varying calibration for the screen pressure is making me wonder if we should have gone with hardware buttons for the input...

Could you try this out on your end and see if you're getting the same results? Either way, take a look and let me know what you think and/or if you know the what's causing the problem.

@azyth Look too :grinning: 
