### PR TITLE
Refactors out manual IDs, replacing them with implementations of getID.

### DIFF
--- a/lib/Ohmbrewer_Equipment.cpp
+++ b/lib/Ohmbrewer_Equipment.cpp
@@ -5,7 +5,6 @@
  * Constructor
  */
 Ohmbrewer::Equipment::Equipment() {
-    _id = 0;
     _stopTime = 0;
     _state = false;
 
@@ -13,23 +12,11 @@ Ohmbrewer::Equipment::Equipment() {
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
- */
-Ohmbrewer::Equipment::Equipment(int id) {
-    _id = id;
-    _stopTime = 0;
-    _state = false;
-}
-
-/**
- * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::Equipment::Equipment(int id, int stopTime, bool state, String currentTask) {
-    _id = id;
+Ohmbrewer::Equipment::Equipment(int stopTime, bool state, String currentTask) {
     _stopTime = stopTime;
     _state = state;
 }
@@ -39,7 +26,6 @@ Ohmbrewer::Equipment::Equipment(int id, int stopTime, bool state, String current
  * @param clonee The Equipment object to copy
  */
 Ohmbrewer::Equipment::Equipment(const Equipment& clonee) {
-    _id = clonee.getID();
     _stopTime = clonee.getStopTime();
     _state = clonee.getState();
     _currentTask = clonee.getCurrentTask();
@@ -50,7 +36,7 @@ Ohmbrewer::Equipment::Equipment(const Equipment& clonee) {
  * @returns The Sprout ID to use for this piece of Equipment
  */
 int Ohmbrewer::Equipment::getID() const {
-    return _id;
+    return -1;
 }
 
 /**

--- a/lib/Ohmbrewer_Equipment.h
+++ b/lib/Ohmbrewer_Equipment.h
@@ -39,7 +39,7 @@ namespace Ohmbrewer {
              * The Equipment ID
              * @returns The Sprout ID to use for this piece of Equipment
              */
-            int getID() const;
+            virtual int getID() const;
             
             /**
              * The Equipment Type
@@ -120,18 +120,11 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
-             */
-            Equipment(int id);
-
-            /**
-             * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
              * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              */
-            Equipment(int id, int stopTime, bool state, String currentTask);
+            Equipment(int stopTime, bool state, String currentTask);
 
             /**
              * Copy Constructor
@@ -213,11 +206,6 @@ namespace Ohmbrewer {
             virtual void whichPins(std::list<int>* pins) = 0;
 
         protected:
-            /**
-             * Equipment ID
-             */
-            int            _id;
-
             /**
              * Designated Stop Time
              */

--- a/lib/Ohmbrewer_Heating_Element.cpp
+++ b/lib/Ohmbrewer_Heating_Element.cpp
@@ -2,19 +2,17 @@
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param elementPins - controlPin always first in <list>
  *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
  *  powerPin - The power pin - on/off line. Digital pin number X.
  */
-Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* elementPins) : Ohmbrewer::Relay(id, elementPins) {
+Ohmbrewer::HeatingElement::HeatingElement(std::list<int>* elementPins) : Ohmbrewer::Relay(elementPins) {
 
     registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param elementPins - controlPin always first in <list>
  *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
  *  powerPin - The power pin - on/off line. Digital pin number X.
@@ -22,8 +20,8 @@ Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* elementPins) :
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::HeatingElement::HeatingElement(int id, std::list<int>* elementPins, int stopTime,
-                                          bool state, String currentTask) : Ohmbrewer::Relay(id, elementPins, stopTime, state, currentTask) {
+Ohmbrewer::HeatingElement::HeatingElement(std::list<int>* elementPins, int stopTime,
+                                          bool state, String currentTask) : Ohmbrewer::Relay(elementPins, stopTime, state, currentTask) {
 
     registerUpdateFunction();
 }

--- a/lib/Ohmbrewer_Heating_Element.h
+++ b/lib/Ohmbrewer_Heating_Element.h
@@ -42,16 +42,14 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param elementPins - controlPin always first in <list>
              *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
              *  powerPin - The power pin - on/off line. Digital pin number X.
              */
-            HeatingElement(int id, std::list<int>* elementPins);
+            HeatingElement(std::list<int>* elementPins);
 
             /**
             * Constructor
-            * @param id The Sprout ID to use for this piece of Equipment
             * @param elementPins - controlPin always first in <list>
             *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
             *  powerPin - The power pin - on/off line. Digital pin number X.
@@ -59,7 +57,7 @@ namespace Ohmbrewer {
             * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
             * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
             */
-            HeatingElement(int id, std::list<int>* elementPins, int stopTime, bool state, String currentTask);
+            HeatingElement(std::list<int>* elementPins, int stopTime, bool state, String currentTask);
 
             /**
              * Copy Constructor

--- a/lib/Ohmbrewer_Onewire.cpp
+++ b/lib/Ohmbrewer_Onewire.cpp
@@ -20,6 +20,14 @@ Ohmbrewer::Onewire::Onewire(int probeIndex) : Ohmbrewer::Probe(){
 }
 
 /**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::Onewire::getID() const {
+    return _probeIndex;
+}
+
+/**
  * @returns the Celsius reading from the specified connected DS18b20 probe
  *      returns -69 for no value
  */

--- a/lib/Ohmbrewer_Onewire.h
+++ b/lib/Ohmbrewer_Onewire.h
@@ -21,6 +21,12 @@ namespace Ohmbrewer {
         Onewire(int probeIndex);
 
         /**
+         * The Equipment ID
+         * @returns The Sprout ID to use for this piece of Equipment
+         */
+        virtual int getID() const;
+
+        /**
          * @returns the Celsius reading from the specified connected DS18b20 probe
          *      returns -69 for no value
          */

--- a/lib/Ohmbrewer_Probe.cpp
+++ b/lib/Ohmbrewer_Probe.cpp
@@ -9,6 +9,14 @@ Ohmbrewer::Probe::Probe(){
 }
 
 /**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::Probe::getID() const {
+    return -1;
+}
+
+/**
 * Destructor
 */
 Ohmbrewer::Probe::~Probe() {

--- a/lib/Ohmbrewer_Probe.h
+++ b/lib/Ohmbrewer_Probe.h
@@ -27,6 +27,12 @@ namespace Ohmbrewer {
         virtual ~Probe();
 
         /**
+         * The Equipment ID
+         * @returns The Sprout ID to use for this piece of Equipment
+         */
+        virtual int getID() const;
+
+        /**
          * @returns the Pin in use for this probe
          */
         virtual int getPin() = 0;

--- a/lib/Ohmbrewer_Pump.cpp
+++ b/lib/Ohmbrewer_Pump.cpp
@@ -2,24 +2,22 @@
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param pumpPin - Single speed pump will only have PowerPin
  */
-Ohmbrewer::Pump::Pump(int id, int pumpPin) : Ohmbrewer::Relay(id, pumpPin) {
+Ohmbrewer::Pump::Pump(int pumpPin) : Ohmbrewer::Relay(pumpPin) {
 
 //    registerUpdateFunction();
 }
 
 /**FIXME
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param pumpPin - Single speed pump will only have PowerPin
  * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::Pump::Pump(int id, int pumpPin, int stopTime,
-                      bool state, String currentTask) : Ohmbrewer::Relay(id, pumpPin, stopTime, state, currentTask) {
+Ohmbrewer::Pump::Pump(int pumpPin, int stopTime,
+                      bool state, String currentTask) : Ohmbrewer::Relay(pumpPin, stopTime, state, currentTask) {
 
 //    registerUpdateFunction();
 }

--- a/lib/Ohmbrewer_Pump.h
+++ b/lib/Ohmbrewer_Pump.h
@@ -42,20 +42,18 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param pumpPin - Single speed pump will only have PowerPin
              */
-            Pump(int id, int pumpPin);
+            Pump(int pumpPin);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param pumpPin - Single speed pump will only have PowerPin
              * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
              * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              */
-            Pump(int id, int pumpPin, int stopTime, bool state, String currentTask);
+            Pump(int pumpPin, int stopTime, bool state, String currentTask);
 
             /**
              * Copy Constructor

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -6,20 +6,18 @@
 
 /**
  * Constructor - creating a RIMS will use 7 equipment IDs
- * @param id The Sprout ID to use for this piece of Equipment
  * @param thermPins list with formatting of: [ temp busPin ;  heating controlPin ; heating powerPin ]
  * @param pumpPin - Single speed pump will only have PowerPin
  * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
  * @param elementPins - controlPin always first in <list>
  */
-Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex ) : Ohmbrewer::Equipment(id) {
-    initRIMS(id, thermPins, pumpPin, safetyIndex);
+Ohmbrewer::RIMS::RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex ) {
+    initRIMS(thermPins, pumpPin, safetyIndex);
 //    registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param thermPins list with formatting of: [ temp busPin ;  heating controlPin ; heating powerPin ]
  * @param pumpPin - Single speed pump will only have PowerPin
  * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
@@ -27,15 +25,14 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int safety
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime,
-                      bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
-    initRIMS(id, thermPins, pumpPin, safetyIndex);
+Ohmbrewer::RIMS::RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime,
+                      bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
+    initRIMS(thermPins, pumpPin, safetyIndex);
 //    registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param thermPins list with formatting of: [ temp busPin ;  heating controlPin ; heating powerPin ]
  * @param pumpPin - Single speed pump will only have PowerPin
  * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
@@ -44,9 +41,9 @@ Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int safety
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  * @param targetTemp The new target temperature in Celsius
  */
-Ohmbrewer::RIMS::RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime,
-                      bool state, String currentTask, const double targetTemp) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
-    initRIMS(id, thermPins, pumpPin, safetyIndex);
+Ohmbrewer::RIMS::RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime,
+                      bool state, String currentTask, const double targetTemp) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
+    initRIMS(thermPins, pumpPin, safetyIndex);
     getTube()->setTargetTemp(targetTemp);
 //    registerUpdateFunction();
 }
@@ -75,18 +72,17 @@ Ohmbrewer::RIMS::~RIMS() {
 
 /**
  * Initializes the members of the RIMS class
- * @param id The Sprout ID to use for this piece of Equipment
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * @param pumpPin - Single speed pump will only have PowerPin
  * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
  */
-void Ohmbrewer::RIMS::initRIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex){
+void Ohmbrewer::RIMS::initRIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex){
     int size = thermPins->size();
     if ( (size == 4) ){
 
         //busPin unused for now
-        _safetySensor = new TemperatureSensor(id+2, new Onewire(safetyIndex));
-        _tube = new Thermostat(id+3, thermPins);
+        _safetySensor = new TemperatureSensor(new Onewire(safetyIndex));
+        _tube = new Thermostat(thermPins);
         //init therm timer?
         //set therm timer?
     }else{//incorrect number of pins supplied
@@ -97,8 +93,16 @@ void Ohmbrewer::RIMS::initRIMS(int id, std::list<int>* thermPins, int pumpPin, i
         pub->publish();
         delete pub;
     }
-    _recirc = new Pump(id+2, pumpPin);
+    _recirc = new Pump(pumpPin);
     _safetyTemp = new Temperature(-69);
+}
+
+/**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::RIMS::getID() const {
+    return _tube->getID();
 }
 
 /**

--- a/lib/Ohmbrewer_RIMS.h
+++ b/lib/Ohmbrewer_RIMS.h
@@ -38,16 +38,14 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ;  heating controlPin ; heating powerPin ]
              * @param pumpPin - Single speed pump will only have PowerPin
              * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
              */
-            RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex);
+            RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ;  heating controlPin ; heating powerPin ]
              * @param pumpPin - Single speed pump will only have PowerPin
              * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
@@ -55,11 +53,10 @@ namespace Ohmbrewer {
              * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              */
-            RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime, bool state, String currentTask);
+            RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime, bool state, String currentTask);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * @param pumpPin - Single speed pump will only have PowerPin
              * @param safetyIndex - onewire index of the probe attached for safetySensor (RIMS tube)
@@ -68,7 +65,7 @@ namespace Ohmbrewer {
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              * @param targetTemp The new target temperature in Celsius
              */
-            RIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime, bool state, String currentTask, const double targetTemp);
+            RIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex, int stopTime, bool state, String currentTask, const double targetTemp);
 
             /**
              * Copy constructor
@@ -85,7 +82,13 @@ namespace Ohmbrewer {
             /**
              * Initializes the members of the RIMS class
              */
-            void initRIMS(int id, std::list<int>* thermPins, int pumpPin, int safetyIndex);
+            void initRIMS(std::list<int>* thermPins, int pumpPin, int safetyIndex);
+
+            /**
+             * The Equipment ID
+             * @returns The Sprout ID to use for this piece of Equipment
+             */
+            virtual int getID() const;
 
             /**
              * The Tube thermostat

--- a/lib/Ohmbrewer_Relay.cpp
+++ b/lib/Ohmbrewer_Relay.cpp
@@ -5,11 +5,10 @@
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param controlPin - Single speed pump will only have ControlPin - on/off line. Digital pin number X.
 
  */
-Ohmbrewer::Relay::Relay(int id, int controlPin) : Ohmbrewer::Equipment(id) {
+Ohmbrewer::Relay::Relay(int controlPin) {
     _controlPin = controlPin;
     pinMode(controlPin, OUTPUT);
     _powerPin = -1;
@@ -17,14 +16,13 @@ Ohmbrewer::Relay::Relay(int id, int controlPin) : Ohmbrewer::Equipment(id) {
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param controlPin - Single speed pump will only have ControlPin - on/off line. Digital pin number X.
  * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::Relay::Relay(int id, int controlPin, int stopTime,
-                        bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
+Ohmbrewer::Relay::Relay(int controlPin, int stopTime,
+                        bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
     _controlPin = controlPin;
     pinMode(controlPin, OUTPUT);
     _powerPin = -1;
@@ -32,18 +30,16 @@ Ohmbrewer::Relay::Relay(int id, int controlPin, int stopTime,
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param relayPins - controlPin always first in <list>
  *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
  *  powerPin - The power pin - on/off line. Digital pin number X.
  */
-Ohmbrewer::Relay::Relay(int id, std::list<int>* relayPins) : Ohmbrewer::Equipment(id) {
+Ohmbrewer::Relay::Relay(std::list<int>* relayPins) {
     initRelay(relayPins);
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param relayPins - controlPin always first in <list>
  *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
  *  powerPin - The power pin - on/off line. Digital pin number X.
@@ -51,8 +47,8 @@ Ohmbrewer::Relay::Relay(int id, std::list<int>* relayPins) : Ohmbrewer::Equipmen
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::Relay::Relay(int id, std::list<int>* relayPins, int stopTime,
-                        bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
+Ohmbrewer::Relay::Relay(std::list<int>* relayPins, int stopTime,
+                        bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
     initRelay(relayPins);
     _state = state;
 }
@@ -106,6 +102,14 @@ void Ohmbrewer::Relay::initRelay(std::list<int>* relayPins) {
         _controlPin = controlPin;
         pinMode(controlPin, OUTPUT);
     }
+}
+
+/**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::Relay::getID() const {
+    return _controlPin;
 }
 
 /**
@@ -245,7 +249,7 @@ int Ohmbrewer::Relay::doDisplay(Ohmbrewer::Screen *screen) {
     screen->print("[");
     screen->setTextColor(screen->WHITE, screen->DEFAULT_BG_COLOR);
 
-    sprintf(relay_id,"%d", _id);
+    sprintf(relay_id,"%d", getID());
     screen->print(relay_id);
 
     screen->resetTextColor();

--- a/lib/Ohmbrewer_Relay.h
+++ b/lib/Ohmbrewer_Relay.h
@@ -36,35 +36,31 @@ namespace Ohmbrewer {
 
             /**
              * Constructor - used by Pump to manually instantiate Relay
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param pumpPin - Single speed pump will only have PowerPin
 
              */
-            Relay(int id, int powerPin);
+            Relay(int powerPin);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param pumpPin - Single speed pump will only have PowerPin
              * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
              * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              */
-            Relay(int id, int powerPin, int stopTime, bool state, String currentTask);
+            Relay(int powerPin, int stopTime, bool state, String currentTask);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param relayPins - controlPin always first in <list>
              *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
              *  powerPin - The power pin - on/off line. Digital pin number X.
              *
              */
-            Relay(int id, std::list<int>* relayPins);
+            Relay(std::list<int>* relayPins);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Equipment
              * @param relayPins - controlPin always first in <list>
              *  controlPin - The Control pin - Data/speed/power level Digital pin number X.
              *  powerPin - The power pin - on/off line. Digital pin number X.
@@ -72,7 +68,7 @@ namespace Ohmbrewer {
              * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
              */
-            Relay(int id, std::list<int>* relayPins, int stopTime, bool state, String currentTask);
+            Relay(std::list<int>* relayPins, int stopTime, bool state, String currentTask);
 
             /**
              * Copy Constructor
@@ -91,6 +87,12 @@ namespace Ohmbrewer {
              *  powerPin - The power pin - on/off line. Digital pin number X.
              */
             void initRelay(std::list<int>* relayPins);
+
+            /**
+             * The Equipment ID
+             * @returns The Sprout ID to use for this piece of Equipment
+             */
+            virtual int getID() const;
 
             /**
              * The power pin - on/off line

--- a/lib/Ohmbrewer_Sprouts.cpp
+++ b/lib/Ohmbrewer_Sprouts.cpp
@@ -61,37 +61,18 @@ int Ohmbrewer::Sprouts::addSprout(String argsStr) {
 
     // Parse the parameters
     String type = String(strtok(params, ","));
-    String idStr   = String(strtok(NULL, ","));
-    int id = idStr.toInt();
-    Serial.println(type);
-    Serial.println(idStr);
-    // If toInt() fails due to a bad parse, it gives 0.
-    if(isFakeZero(idStr)) {
-        delete params;
-        return -1;
-    }
-
-    // Make sure ID isn't in use
-    std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin();
-
-    for (itr; itr != _sprouts->end(); itr++) {
-        if (((*itr)->getID() == id) && (type.equalsIgnoreCase((*itr)->getType()))) {
-            delete params;
-            return -2;
-        }
-    }
 
     // Now, depending on the type we need to parse differently. Then we add the Equipment.
     if(type.equalsIgnoreCase(Ohmbrewer::TemperatureSensor::TYPE_NAME)) {
-        errorCode = addTemperatureSensor(id, params);
+        errorCode = addTemperatureSensor(params);
     } else if(type.equalsIgnoreCase(Ohmbrewer::Pump::TYPE_NAME)) {
-        errorCode = addPump(id, params);
+        errorCode = addPump(params);
     } else if(type.equalsIgnoreCase(Ohmbrewer::HeatingElement::TYPE_NAME)) {
-        errorCode = addHeatingElement(id, params);
+        errorCode = addHeatingElement(params);
     } else if(type.equalsIgnoreCase(Ohmbrewer::Thermostat::TYPE_NAME)) {
-        errorCode = addThermostat(id, params);
+        errorCode = addThermostat(params);
     } else if(type.equalsIgnoreCase(Ohmbrewer::RIMS::TYPE_NAME)) {
-        errorCode = addRIMS(id, params);
+        errorCode = addRIMS(params);
     } else {
         // Trying to add an unrecognized Equipment Type.
         errorCode = -5;
@@ -112,7 +93,7 @@ int Ohmbrewer::Sprouts::addSprout(String argsStr) {
 
     // Otherwise, refresh the screen and return success.
     _screen->initScreen();
-    return id; // Success!
+    return _sprouts->back()->getID(); // Success!
 }
 
 /**
@@ -214,12 +195,6 @@ int Ohmbrewer::Sprouts::removeSprout(String argsStr) {
             _sprouts->erase(itr);
             delete params;
             _screen->initScreen(); // Gotta do this to clear artifacts from the screen
-
-            if(_sprouts->size() == 0) {
-                // No use in running the update timer if we have no Sprouts
-                _periodicUpdateTimer->stop();
-            }
-
             return id; // Success!
         }
     }
@@ -332,17 +307,15 @@ int Ohmbrewer::Sprouts::parseOnewireSensorPins(char *params, int &index) {
 
 /**
   * Adds a Temperature Sensor
-  * @param id The ID for the equipment
   * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
   * @return Error or success code, according to the requirements specified by addSprout
   */
-int Ohmbrewer::Sprouts::addTemperatureSensor(int id, char* params) {
+int Ohmbrewer::Sprouts::addTemperatureSensor(char* params) {
     int index;
-    Serial.println("Parsing");
     int errorCode = parseOnewireSensorPins(params, index);
 
     if(errorCode == 0) {
-        _sprouts->push_back(new Ohmbrewer::TemperatureSensor( id, new Ohmbrewer::Onewire(index) ));
+        _sprouts->push_back(new Ohmbrewer::TemperatureSensor( new Ohmbrewer::Onewire(index) ));
     }
 
     return errorCode;

--- a/lib/Ohmbrewer_Sprouts.h
+++ b/lib/Ohmbrewer_Sprouts.h
@@ -160,11 +160,10 @@ namespace Ohmbrewer {
 
         /**
          * Adds a Temperature Sensor based on the next chunk of parsed data.
-         * @param id The ID for the equipment
          * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
          * @return Error or success code, according to the requirements specified by addSprout
          */
-        int addTemperatureSensor(int id, char* params);
+        int addTemperatureSensor(char* params);
 
         /**
          * Parses a given string of characters into the pins for a Pump
@@ -176,11 +175,10 @@ namespace Ohmbrewer {
 
         /**
          * Adds a Pump based on the next chunk of parsed data.
-         * @param id The ID for the equipment
          * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
          * @return Error or success code, according to the requirements specified by addSprout
          */
-        int addPump(int id, char* params);
+        int addPump(char* params);
 
         /**
          * Parses a given string of characters into the pins for a Heating Element
@@ -192,11 +190,10 @@ namespace Ohmbrewer {
 
         /**
          * Adds a Heating Element based on the next chunk of parsed data.
-         * @param id The ID for the equipment
          * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
          * @return Error or success code, according to the requirements specified by addSprout
          */
-        int addHeatingElement(int id, char* params);
+        int addHeatingElement(char* params);
 
         /**
          * Parses a given string of characters into the pins for a Thermostat
@@ -208,11 +205,10 @@ namespace Ohmbrewer {
 
         /**
          * Adds a Thermostat based on the next chunk of parsed data.
-         * @param id The ID for the equipment
          * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
          * @return Error or success code, according to the requirements specified by addSprout
          */
-        int addThermostat(int id, char* params);
+        int addThermostat(char* params);
 
         /**
          * Parses a given string of characters into the pins for a RIMS
@@ -226,11 +222,10 @@ namespace Ohmbrewer {
 
         /**
          * Adds a RIMS based on the next chunk of parsed data.
-         * @param id The ID for the equipment
          * @param params The buffer to use for strtok'ing. This method will not delete the buffer!
          * @return Error or success code, according to the requirements specified by addSprout
          */
-        int addRIMS(int id, char* params);
+        int addRIMS(char* params);
     };
 };
 

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -6,26 +6,23 @@
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param busPin The Digital Pin that the temp probes are attached to. NOTE: for ds18b20 should always be D0
  */
-Ohmbrewer::TemperatureSensor::TemperatureSensor(int id, Probe* probe) : Ohmbrewer::Equipment(id) {
+Ohmbrewer::TemperatureSensor::TemperatureSensor(Probe* probe) {
     _probe = probe;                 //For now all probes are all onewire
     _lastReading = new Temperature(-69);
     _lastReadTime = Time.now();
-
 //    registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Equipment
  * @param busPin The Digital Pin that the temp probes are attached to. NOTE: for ds18b20 should always be D0
  * @param stopTime The time at which the Equipment should shut off, assuming it isn't otherwise interrupted
  * @param state Whether the Equipment is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Equipment believes it should be processing
  */
-Ohmbrewer::TemperatureSensor::TemperatureSensor(int id,  Probe* probe, int stopTime, bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
+Ohmbrewer::TemperatureSensor::TemperatureSensor(Probe* probe, int stopTime, bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
     _probe = probe;
     _lastReading = new Temperature(-69);
     _lastReadTime = Time.now();
@@ -49,6 +46,14 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(const TemperatureSensor& clonee)
 Ohmbrewer::TemperatureSensor::~TemperatureSensor() {
     delete _lastReading;
     delete _probe;
+}
+
+/**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::TemperatureSensor::getID() const {
+    return _probe->getID();
 }
 
 /**
@@ -166,7 +171,7 @@ int Ohmbrewer::TemperatureSensor::doDisplay(Ohmbrewer::Screen *screen) {
     char relay_id[2];
     char tempStr [10];
 
-    sprintf(relay_id,"%d", _id);
+    sprintf(relay_id,"%d", getId());
     if(screen->getSettings()->isTempUnitCelsius()){
         getTemp()->toStrC(tempStr);
     } else {

--- a/lib/Ohmbrewer_Temperature_Sensor.h
+++ b/lib/Ohmbrewer_Temperature_Sensor.h
@@ -36,20 +36,18 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this TemperatureSensor
              * @param pins The list of physical pins this TemperatureSensor is attached to
              */
-            TemperatureSensor(int id, Probe* probe);
+            TemperatureSensor(Probe* probe);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this TemperatureSensor
              * @param pins The list of physical pins this TemperatureSensor is attached to
              * @param stopTime The time at which the TemperatureSensor should shut off, assuming it isn't otherwise interrupted
              * @param state Whether the TemperatureSensor is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the TemperatureSensor believes it should be processing
              */
-            TemperatureSensor(int id, Probe* probe, int stopTime, bool state, String currentTask);
+            TemperatureSensor(Probe* probe, int stopTime, bool state, String currentTask);
 
             /**
              * Copy Constructor
@@ -61,6 +59,12 @@ namespace Ohmbrewer {
              * Destructor
              */
             virtual ~TemperatureSensor();
+
+            /**
+             * The Equipment ID
+             * @returns The Sprout ID to use for this piece of Equipment
+             */
+            virtual int getID() const;
 
             /**
              * The Bus pin - Data input line

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -6,25 +6,23 @@
 
 /**
  * Constructor - creating a Thermostat will use up 3 equipment IDs
- * @param id The Sprout ID to use for this piece of Thermostat
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
  */
-Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins) : Ohmbrewer::Equipment(id) {
-    initThermostat(id, thermPins);
+Ohmbrewer::Thermostat::Thermostat(std::list<int>* thermPins) {
+    initThermostat(thermPins);
 //    _timer = pidTime;
 //    registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Thermostat
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
  * @param targetTemp The new target temperature in Celsius
  */
-Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, const double targetTemp) : Ohmbrewer::Equipment(id) {
-    initThermostat(id, thermPins);
+Ohmbrewer::Thermostat::Thermostat(std::list<int>* thermPins, const double targetTemp) {
+    initThermostat(thermPins);
     _targetTemp->fromC(targetTemp);
 //    _timer = pidTime;
 //    registerUpdateFunction();
@@ -32,23 +30,21 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, const doubl
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Thermostat
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
  * @param stopTime The time at which the Thermostat should shut off, assuming it isn't otherwise interrupted
  * @param state Whether the Thermostat is ON (or OFF). True => ON, False => OFF
  * @param currentTask The unique identifier of the task that the Thermostat believes it should be processing
  */
-Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, int stopTime,
-                                  bool state, String currentTask) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
-    initThermostat(id, thermPins);
+Ohmbrewer::Thermostat::Thermostat(std::list<int>* thermPins, int stopTime,
+                                  bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
+    initThermostat(thermPins);
 //    _timer = pidTime;
 //    registerUpdateFunction();
 }
 
 /**
  * Constructor
- * @param id The Sprout ID to use for this piece of Thermostat
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
  * @param stopTime The time at which the Thermostat should shut off, assuming it isn't otherwise interrupted
@@ -56,10 +52,10 @@ Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, int stopTim
  * @param currentTask The unique identifier of the task that the Thermostat believes it should be processing
  * @param targetTemp The new target temperature in Celsius
  */
-Ohmbrewer::Thermostat::Thermostat(int id, std::list<int>* thermPins, int stopTime,
+Ohmbrewer::Thermostat::Thermostat(std::list<int>* thermPins, int stopTime,
                                   bool state, String currentTask,
-                                  const double targetTemp) : Ohmbrewer::Equipment(id, stopTime, state, currentTask) {
-    initThermostat(id, thermPins);
+                                  const double targetTemp) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
+    initThermostat(thermPins);
     _targetTemp->fromC(targetTemp);
 //    _timer = pidTime;
 //    registerUpdateFunction();
@@ -88,21 +84,20 @@ Ohmbrewer::Thermostat::~Thermostat() {
 
 /**
  * logic for initializing equipment and PID in the constructors
- * @param id The Sprout ID to use for this piece of Thermostat
  * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
  * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
  */
-void Ohmbrewer::Thermostat::initThermostat(int id, std::list<int>* thermPins){
+void Ohmbrewer::Thermostat::initThermostat(std::list<int>* thermPins){
 
     // Initialize equipment components
     int size = thermPins->size();
-    if ( (size == 4) ) {
+    if (size == 4) {
 
         thermPins->pop_front();//remove busPIN - unused for now.
         int index = thermPins->front();
-        _tempSensor = new TemperatureSensor(id + 1, new Onewire(index));
+        _tempSensor = new TemperatureSensor(new Onewire(index));
         thermPins->pop_front();
-        _heatingElm = new HeatingElement(id+3, thermPins);
+        _heatingElm = new HeatingElement(thermPins);
     } else {//not correct number on PINS
         // Publish error
         Ohmbrewer::Publisher::publish_map_t pMap;
@@ -135,6 +130,14 @@ void Ohmbrewer::Thermostat::initThermostat(int id, std::list<int>* thermPins){
     //Timer timer(5000, doPID);
     //_timer = &timer;
 
+}
+
+/**
+ * The Equipment ID
+ * @returns The Sprout ID to use for this piece of Equipment
+ */
+int Ohmbrewer::Thermostat::getID() const {
+    return _heatingElm->getID();
 }
 
 /**

--- a/lib/Ohmbrewer_Thermostat.h
+++ b/lib/Ohmbrewer_Thermostat.h
@@ -38,35 +38,31 @@ namespace Ohmbrewer {
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Thermostat
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
              */
-            Thermostat(int id, std::list<int>* thermPins);
+            Thermostat(std::list<int>* thermPins);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Thermostat
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
              * @param targetTemp The new target temperature in Celsius
              */
-            Thermostat(int id, std::list<int>* thermPins, const double targetTemp);
+            Thermostat(std::list<int>* thermPins, const double targetTemp);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Thermostat
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
              * @param stopTime The time at which the Thermostat should shut off, assuming it isn't otherwise interrupted
              * @param state Whether the Thermostat is ON (or OFF). True => ON, False => OFF
              * @param currentTask The unique identifier of the task that the Thermostat believes it should be processing
              */
-            Thermostat(int id, std::list<int>* thermPins, int stopTime, bool state, String currentTask);
+            Thermostat(std::list<int>* thermPins, int stopTime, bool state, String currentTask);
 
             /**
              * Constructor
-             * @param id The Sprout ID to use for this piece of Thermostat
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
              * @param stopTime The time at which the Thermostat should shut off, assuming it isn't otherwise interrupted
@@ -74,7 +70,7 @@ namespace Ohmbrewer {
              * @param currentTask The unique identifier of the task that the Thermostat believes it should be processing
              * @param targetTemp The new target temperature in Celsius
              */
-            Thermostat(int id, std::list<int>* thermPins, int stopTime, bool state, String currentTask, const double targetTemp);
+            Thermostat(std::list<int>* thermPins, int stopTime, bool state, String currentTask, const double targetTemp);
 
             /**
              * Copy Constructor
@@ -89,11 +85,16 @@ namespace Ohmbrewer {
 
             /**
              * logic for initializing the constructors
-             * @param id The Sprout ID to use for this piece of Thermostat
              * @param thermPins list with formatting of: [ temp busPin ; onewire index ; heating controlPin ; heating powerPin ]
              * NOTE: if a Pin value is not enabled pass -1 as the value for that pin.
              */
-            void initThermostat(int id, std::list<int>* thermPins);
+            void initThermostat(std::list<int>* thermPins);
+
+            /**
+             * The Equipment ID
+             * @returns The Sprout ID to use for this piece of Equipment
+             */
+            virtual int getID() const;
 
             /**
              * The Thermostat's temperature sensor


### PR DESCRIPTION
Resolves #32.

Note: this changes the /add Particle function's API (no longer need to pass in the ID).

Waiting on #76 before this can be merged in. We'll need to update the appropriate communication methods in Ohmbrewer to accommodate the API change - I'll make an issue for that before this gets merged in.
