### PR TITLE
Adds the ability to remove all Sprouts or all of a given type by specifying all,all or TYPE,all when calling /remove

### DIFF
--- a/lib/Ohmbrewer_Rhizome.h
+++ b/lib/Ohmbrewer_Rhizome.h
@@ -55,6 +55,7 @@ namespace Ohmbrewer {
         class RemoveSproutError {
             public:
 
+            static const int NONE = 0;
             static const int INVALID_ID = -1;
             static const int SPROUT_NOT_FOUND = -2;
         };
@@ -108,7 +109,7 @@ namespace Ohmbrewer {
         int updateSprout(String argsStr);
 
         /**
-         * Dynamically removes Equipment to the Rhizome.
+         * Dynamically removes one or more Equipment from the Rhizome.
          *
          * The argument string for this function must match the following format:
          * TYPE,ID
@@ -117,7 +118,34 @@ namespace Ohmbrewer {
          * @returns Equipment ID if successful,
          *          (negative) error codes if unsuccessful (see Rhizome::RemoveSproutError)
          */
-        int removeSprout(String argsStr);
+        int removeSprouts(String argsStr);
+
+        /**
+         * Dynamically removes Equipment from the Rhizome.
+         *
+         * @param type The type of Sprout to remove
+         * @param id The ID of the Sprout to remove
+         * @returns Equipment ID if successful,
+         *          (negative) error codes if unsuccessful (see Rhizome::RemoveSproutError)
+         */
+        int removeSprout(String type, int id);
+
+        /**
+         * Removes all Equipment from the Rhizome.
+         *
+         * @returns 0 if successful
+         *          (negative) error codes if unsuccessful (see Rhizome::RemoveSproutError)
+         */
+        int removeAllSprouts();
+
+        /**
+         * Removes all Equipment of a given type from the Rhizome.
+         *
+         * @param type The type of Sprout to remove
+         * @returns 0 if successful
+         *          (negative) error codes if unsuccessful (see Rhizome::RemoveSproutError)
+         */
+        int removeAllSprouts(String type);
 
         /**
          * Publishes any periodic updates that need to be published.
@@ -289,6 +317,12 @@ namespace Ohmbrewer {
          * Rebuilds index based on current list of equipment
          */
         void rebuildIndex();
+
+        /**
+         * Rebuilds the Sprout index and refreshes the Screen
+         */
+        void refreshSprouts();
+
     };
 };
 

--- a/lib/Ohmbrewer_Screen.cpp
+++ b/lib/Ohmbrewer_Screen.cpp
@@ -166,7 +166,7 @@ unsigned long Ohmbrewer::Screen::displayManualRelays() {
             print("Temp ");
             writeDegree();
             print("C ");
-            ((Ohmbrewer::Relay*)(*itr))->display(this);
+            ((Ohmbrewer::TemperatureSensor*)(*itr))->display(this);
         }
     }
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {
@@ -174,7 +174,7 @@ unsigned long Ohmbrewer::Screen::displayManualRelays() {
         if (strcmp((*itr)->getType(), Pump::TYPE_NAME) == 0) {
             setTextColor(CYAN, DEFAULT_BG_COLOR);
             print("Pump    ");
-            ((Ohmbrewer::Relay*)(*itr))->display(this);
+            ((Ohmbrewer::Pump*)(*itr))->display(this);
         }
     }
     for (std::deque<Ohmbrewer::Equipment*>::iterator itr = _sprouts->begin(); itr != _sprouts->end(); itr++) {


### PR DESCRIPTION
Resolves #60 .

It builds, but I haven't tested it because I didn't tote my Rhizome to Ithaca with me. If someone could give it a go, I'd appreciate it. 

To test, add two or more pumps, two or more temperature sensors, and one other piece of equipment (or something along those lines). Then try:
`particle call RHIZOME remove temp,all`
and verify that all temperature sensors were removed. Then
`particle call RHIZOME remove all,all`
and verify that all remaining equipment was removed. It may also be interesting to try running both versions of the call when there is no equipment attached to verify that it returns the code that the documentation advertises.

@Ohmbrewer/hops-team Whatcha think?
