### PR TITLE
Adds a constant to represent invalid temperature readings.

### DIFF
--- a/lib/Ohmbrewer_Onewire.cpp
+++ b/lib/Ohmbrewer_Onewire.cpp
@@ -1,4 +1,4 @@
-
+#include "Ohmbrewer_Temperature.h"
 #include "Ohmbrewer_Onewire.h"
 #include "ds18x20.h"
 #include "onewire.h"
@@ -29,7 +29,7 @@ int Ohmbrewer::Onewire::getID() const {
 
 /**
  * @returns the Celsius reading from the specified connected DS18b20 probe
- *      returns -69 for no value
+ *      returns Temperature::INVALID_TEMPERATURE for no value
  */
 double Ohmbrewer::Onewire::getReading(){
     //char uid[8];                   //need the unique ID of the probe to search for.
@@ -38,7 +38,7 @@ double Ohmbrewer::Onewire::getReading(){
 
     uint8_t subzero, cel, celFracBits;        //local vars
 //    char msg[100];
-    double tempC = -69;
+    double tempC = Temperature::INVALID_TEMPERATURE;
     //log("Starting measurement");
     //Asks all DS18x20 devices to start temperature measurement, takes up to 750ms at max resolution
     DS18X20_start_meas( DS18X20_POWER_PARASITE, NULL );
@@ -104,7 +104,7 @@ double Ohmbrewer::Onewire::getReading(){
 //                        if (i == numSensors - 1) {
 //                            //sprintf(msg, "Sensor %s not connected", _probeId); //TODO inject probe ID?
 //                            //log(msg);
-//                            tempC = -69.69;//double error :)
+//                            tempC = Temperature::INVALID_TEMPERATURE;
 //                        }
 //                    }
 //                }
@@ -201,10 +201,9 @@ void Ohmbrewer::Onewire::displayProbeIds(Ohmbrewer::Screen *screen){
             else {//not sure this block is actually needed
                 if (i == numSensors - 1) {
                     //error
-                    tempC = -69;
                     screen->print(probeId);
                     screen->print(" : ");
-                    screen->println(tempC);
+                    screen->println(Temperature::INVALID_TEMPERATURE);
                 }
             }
         }

--- a/lib/Ohmbrewer_Onewire.h
+++ b/lib/Ohmbrewer_Onewire.h
@@ -28,7 +28,7 @@ namespace Ohmbrewer {
 
         /**
          * @returns the Celsius reading from the specified connected DS18b20 probe
-         *      returns -69 for no value
+         *      returns Temperature::INVALID_TEMPERATURE for no value
          */
         double getReading();
 

--- a/lib/Ohmbrewer_RIMS.cpp
+++ b/lib/Ohmbrewer_RIMS.cpp
@@ -2,6 +2,7 @@
 #include "Ohmbrewer_Screen.h"
 #include "Ohmbrewer_Publisher.h"
 #include "Ohmbrewer_Onewire.h"
+#include "Ohmbrewer_Temperature.h"
 
 
 /**
@@ -94,7 +95,7 @@ void Ohmbrewer::RIMS::initRIMS(std::list<int>* thermPins, int pumpPin, int safet
         delete pub;
     }
     _recirc = new Pump(pumpPin);
-    _safetyTemp = new Temperature(-69);
+    _safetyTemp = new Temperature();
 }
 
 /**

--- a/lib/Ohmbrewer_Temperature.cpp
+++ b/lib/Ohmbrewer_Temperature.cpp
@@ -1,5 +1,11 @@
 #include "Ohmbrewer_Temperature.h"
 
+/**
+ * Constructor.
+ */
+Ohmbrewer::Temperature::Temperature() {
+    _temp = Temperature::INVALID_TEMPERATURE;
+}
 
 /**
  * Constructor.

--- a/lib/Ohmbrewer_Temperature.h
+++ b/lib/Ohmbrewer_Temperature.h
@@ -17,6 +17,16 @@ namespace Ohmbrewer {
         public:
 
             /**
+             * Represents a temperature that doesn't make sense. Used for bad readings.
+             */
+            const static constexpr double INVALID_TEMPERATURE = -69.0;
+
+            /**
+             * Constructor.
+             */
+            Temperature();
+
+            /**
              * Constructor.
              * @param temp The temperature in Celsius
              */

--- a/lib/Ohmbrewer_Temperature_Sensor.cpp
+++ b/lib/Ohmbrewer_Temperature_Sensor.cpp
@@ -2,6 +2,7 @@
 #include "Ohmbrewer_Screen.h"
 #include "Ohmbrewer_Onewire.h"
 #include "Ohmbrewer_Publisher.h"
+#include "Ohmbrewer_Temperature.h"
 
 
 /**
@@ -10,7 +11,7 @@
  */
 Ohmbrewer::TemperatureSensor::TemperatureSensor(Probe* probe) {
     _probe = probe;                 //For now all probes are all onewire
-    _lastReading = new Temperature(-69);
+    _lastReading = new Temperature();
     _lastReadTime = Time.now();
 //    registerUpdateFunction();
 }
@@ -24,7 +25,7 @@ Ohmbrewer::TemperatureSensor::TemperatureSensor(Probe* probe) {
  */
 Ohmbrewer::TemperatureSensor::TemperatureSensor(Probe* probe, int stopTime, bool state, String currentTask) : Ohmbrewer::Equipment(stopTime, state, currentTask) {
     _probe = probe;
-    _lastReading = new Temperature(-69);
+    _lastReading = new Temperature();
     _lastReadTime = Time.now();
 //    registerUpdateFunction();
 }

--- a/lib/Ohmbrewer_Thermostat.cpp
+++ b/lib/Ohmbrewer_Thermostat.cpp
@@ -110,7 +110,7 @@ void Ohmbrewer::Thermostat::initThermostat(std::list<int>* thermPins){
         setState(false);
         return;
     }
-    _targetTemp = new Temperature(-69);
+    _targetTemp = new Temperature();
 
     // PID set up
     _thermPID = new PID(&input, &output, &setPoint,


### PR DESCRIPTION
@Ohmbrewer/hops-team 
This is one of those minor little tweaks that should help with consistency. I've added a constant to represent invalid temperature values (set to the existing implementation of "-69.0") and added a default constructor for the Temperature object that doesn't take any parameters.
