### PR TITLE
New version for updated rhizome with non touch screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SOURCE_FILES
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_Main.cpp
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_TempUnit.h
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_TempUnit.cpp
-    ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_WiFi.h    
+    ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_WiFi.h
     ../lib/Ohmbrewer_Menu/Ohmbrewer_Menu_WiFi.cpp
     ../lib/Ohmbrewer_Onewire.cpp
     ../lib/Ohmbrewer_Onewire.h
@@ -46,12 +46,15 @@ set(SOURCE_FILES
     ../lib/Ohmbrewer_Thermostat.h
     ../lib/Ohmbrewer_Thermostat.cpp
 #external libraries
+
     ../../Adafruit_ILI9341/firmware/Adafruit_ILI9341.h
     ../../Adafruit_ILI9341/firmware/Adafruit_ILI9341.cpp
     ../../Adafruit_mfGFX_IDE/firmware/Adafruit_mfGFX.h
     ../../Adafruit_mfGFX_IDE/firmware/Adafruit_mfGFX.cpp
     ../../Adafruit_mfGFX_IDE/firmware/fonts.h
     ../../Adafruit_mfGFX_IDE/firmware/fonts.cpp
+
+
     ../../particle-ds18x20/firmware/ds18x20.cpp
     ../../particle-ds18x20/firmware/ds18x20.h
     ../../particle-ds18x20/firmware/crc8.cpp
@@ -62,6 +65,12 @@ set(SOURCE_FILES
     ../../Spark-PID/firmware/pid.h
     ../../Touch_4Wire/firmware/Touch_4Wire.cpp
     ../../Touch_4Wire/firmware/Touch_4Wire.h
+    ../../Adafruit_ST7735/Adafruit_ST7735.h
+    ../../Adafruit_ST7735/Adafruit_ST7735.cpp
+    ../../Adafruit_GFX/Adafruit_GFX.h
+    ../../Adafruit_GFX/Adafruit_GFX.cpp
+    ../../Adafruit_GFX/gfxfont.h
+    ../../Adafruit_GFX/glcdfont.c
 )
 
 if(DEVICE_TYPE)

--- a/lib/Ohmbrewer_Screen.cpp
+++ b/lib/Ohmbrewer_Screen.cpp
@@ -21,7 +21,7 @@ Ohmbrewer::Screen::Screen(uint8_t CS,
                           uint8_t RS,
                           uint8_t RST,
                           std::deque< Ohmbrewer::Equipment* >* sprouts,
-                          Ohmbrewer::RuntimeSettings *settings) : Adafruit_ILI9341(CS, RS, RST) {
+                          Ohmbrewer::RuntimeSettings *settings) : Adafruit_ST7735(CS, RS, RST) {
     _sprouts = sprouts;
     _settings= settings;
 
@@ -69,7 +69,7 @@ void Ohmbrewer::Screen::reinitScreen() {
     fillScreen(DEFAULT_BG_COLOR);
 
     // Draw the buttons that are always there
-    drawButtons();
+    // drawButtons();
 
     // Reset the cursor
     setCursor(LEFT, TOP);
@@ -84,7 +84,7 @@ unsigned long Ohmbrewer::Screen::displayHeader() {
 
     // Add the title
     setCursor(0, 0);
-    setTextColor(ILI9341_WHITE, DEFAULT_BG_COLOR);
+    setTextColor(ST7735_WHITE, DEFAULT_BG_COLOR);
     setTextSize(3);
     println("  OHMBREWER");
     resetTextSizeAndColor();
@@ -110,7 +110,7 @@ void Ohmbrewer::Screen::printMargin(const uint8_t current) {
  */
 void Ohmbrewer::Screen::drawButtons() {
 
-    setTextColor(ILI9341_WHITE, DEFAULT_BG_COLOR);
+    setTextColor(ST7735_WHITE, DEFAULT_BG_COLOR);
 
     // make the buttons
     fillRect(LEFT, BUTTONTOP, BUTTONSIZE, BUTTONSIZE, DEFAULT_BG_COLOR);
@@ -370,7 +370,7 @@ unsigned long Ohmbrewer::Screen::displayRIMS() {
 unsigned long Ohmbrewer::Screen::displayStatusUpdate(char *statusUpdate) {
     unsigned long start = micros();
 
-    setTextColor(ILI9341_RED, DEFAULT_BG_COLOR);
+    setTextColor(ST7735_RED, DEFAULT_BG_COLOR);
     setCursor(LEFT, BUTTONTOP - 40);
     resetTextSize();
     println(statusUpdate);
@@ -379,7 +379,7 @@ unsigned long Ohmbrewer::Screen::displayStatusUpdate(char *statusUpdate) {
 }
 
 /**
- * Checks for a touch event and triggers actions 
+ * Checks for a touch event and triggers actions
  *  if the the touch was on a screen "button".
  * @returns Time it took to run the function
  */
@@ -404,14 +404,14 @@ unsigned long Ohmbrewer::Screen::captureButtonPress() {
     // Scale from ~0->1000 to tft.width using the calibration #'s
     p.x = map(p.x, TS_MINX, TS_MAXX, 0, width()-35); // This -35 is a dirty hack. We need to fix the scaling to get this working without it.
     p.y = map(p.y, TS_MINY, TS_MAXY, 0, height());
-    
+
     // Each of these should pad out with spaces on the right
     sprintf(printx, "x is %-5d", p.x);
     sprintf(printy, "y is %-5d", p.y);
-    
+
     String statusUpdate = String(printx);
     statusUpdate.concat(printy);
-    
+
     if (p.y >= BUTTONTOP) {
 
         if (p.x > 0 && p.x <= BUTTONSIZE) {
@@ -439,12 +439,12 @@ unsigned long Ohmbrewer::Screen::captureButtonPress() {
             statusUpdate.concat("                    ");
 //            Serial.println("Pressing Nothing!    ");
         }
-        
+
         // Barf it onto the display...
         statusUpdate.toCharArray(status, 40);
         displayStatusUpdate(status);
     }
-    
+
     Serial.print("X = "); Serial.print(p.x);
     Serial.print("\tY = "); Serial.print(p.y);
     Serial.print("\tPressure = "); Serial.println(p.z);

--- a/lib/Ohmbrewer_Screen.h
+++ b/lib/Ohmbrewer_Screen.h
@@ -13,7 +13,8 @@
 #define YM A2
 
 #include <deque>
-#include "Adafruit_ILI9341.h"
+// #include "Adafruit_ILI9341.h"
+#include "Adafruit_ST7735.h"
 #include "application.h"
 #include "Touch_4Wire.h"
 #include "Ohmbrewer_Runtime_Settings.h"
@@ -26,7 +27,8 @@ namespace Ohmbrewer {
 
     // TODO: Add a member object to Ohmbrewer::Screen that represents the capacitive touch capabilities
     // (e.g. an instance of Adafruit Touch 4Wire TouchScreen)
-    class Screen : public Adafruit_ILI9341 {
+    // class Screen : public Adafruit_ILI9341 {
+    class Screen : public Adafruit_ST7735 {
 
         public:
 
@@ -37,15 +39,24 @@ namespace Ohmbrewer {
             static const int      BOTTOM = 320;
             static const int      BUTTONTOP = 260;
             static const uint8_t  DEFAULT_TEXT_SIZE = 2;
-            static const uint16_t DEFAULT_TEXT_COLOR = ILI9341_GREEN;
-            static const uint16_t DEFAULT_BG_COLOR = ILI9341_BLACK;
-            static const uint16_t RED = ILI9341_RED;
-            static const uint16_t BLACK = ILI9341_BLACK;
-            static const uint16_t BLUE = ILI9341_BLUE;
-            static const uint16_t GREEN = ILI9341_GREEN;
-            static const uint16_t WHITE = ILI9341_WHITE;
-            static const uint16_t YELLOW = ILI9341_YELLOW;
-            static const uint16_t CYAN = ILI9341_CYAN;
+            // static const uint16_t DEFAULT_TEXT_COLOR = ILI9341_GREEN;
+            // static const uint16_t DEFAULT_BG_COLOR = ILI9341_BLACK;
+            // static const uint16_t RED = ILI9341_RED;
+            // static const uint16_t BLACK = ILI9341_BLACK;
+            // static const uint16_t BLUE = ILI9341_BLUE;
+            // static const uint16_t GREEN = ILI9341_GREEN;
+            // static const uint16_t WHITE = ILI9341_WHITE;
+            // static const uint16_t YELLOW = ILI9341_YELLOW;
+            // static const uint16_t CYAN = ILI9341_CYAN;
+            static const uint16_t DEFAULT_TEXT_COLOR = ST7735_GREEN;
+            static const uint16_t DEFAULT_BG_COLOR = ST7735_BLACK;
+            static const uint16_t RED = ST7735_RED;
+            static const uint16_t BLACK = ST7735_BLACK;
+            static const uint16_t BLUE = ST7735_BLUE;
+            static const uint16_t GREEN = ST7735_GREEN;
+            static const uint16_t WHITE = ST7735_WHITE;
+            static const uint16_t YELLOW = ST7735_YELLOW;
+            static const uint16_t CYAN = ST7735_CYAN;
 
 
             // This is calibration data for the raw touch data to the screen coordinates
@@ -172,9 +183,9 @@ namespace Ohmbrewer {
              * @returns Time it took to run the function
              */
             unsigned long displayStatusUpdate(char *statusUpdate);
-            
+
             /**
-             * Checks for a touch event and triggers actions 
+             * Checks for a touch event and triggers actions
              *  if the the touch was on a screen "button".
              * @returns Time it took to run the function
              */
@@ -214,15 +225,15 @@ namespace Ohmbrewer {
              * Pointer to the Rhizome's runtime settings
              */
             RuntimeSettings* _settings;
-            
-            /** 
+
+            /**
              *  The touchscreen object used to check for taps on the screen
              */
             TouchScreen* _ts;
-            
+
             /**
              * Pointer to the current menu
-             */            
+             */
             Menu* _currentMenu;
 
             /**


### PR DESCRIPTION
ok, so this i broken right now..... a bunch of compile errors dealing with dependiecies and functions apparently no longer declared. 

you do have to add the actual package files to the parent directory as well. 

@kyleoliveira  I dont even remeber what the function call to begin() (line 68) was supposed to do, and was that something built in to another package or was that our function. but that appears to be a problem chiild in here. (one of many probably)